### PR TITLE
feat: patch refiner

### DIFF
--- a/backend/pkg/providers/openai/config.yml
+++ b/backend/pkg/providers/openai/config.yml
@@ -52,7 +52,7 @@ generator:
 refiner:
   model: gpt-5
   n: 1
-  max_tokens: 8192
+  max_tokens: 16384
   reasoning:
     effort: high
   price:

--- a/backend/pkg/providers/performers.go
+++ b/backend/pkg/providers/performers.go
@@ -13,6 +13,7 @@ import (
 	"pentagi/pkg/providers/pconfig"
 	"pentagi/pkg/tools"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vxcontrol/langchaingo/llms"
 )
 
@@ -170,14 +171,24 @@ func (fp *flowProvider) performSubtasksGenerator(
 func (fp *flowProvider) performSubtasksRefiner(
 	ctx context.Context,
 	taskID int64,
+	plannedSubtasks []database.Subtask,
 	systemRefinerTmpl, userRefinerTmpl, input string,
 ) ([]tools.SubtaskInfo, error) {
 	var (
-		subtaskList  tools.SubtaskList
+		subtaskPatch tools.SubtaskPatch
 		chain        []llms.MessageContent
 		optAgentType = pconfig.OptionsTypeRefiner
 		msgChainType = database.MsgchainTypeRefiner
 	)
+
+	logger := logrus.WithContext(ctx).WithFields(logrus.Fields{
+		"task_id":        taskID,
+		"planned_count":  len(plannedSubtasks),
+		"msg_chain_type": msgChainType,
+		"opt_agent_type": optAgentType,
+	})
+
+	logger.Debug("starting subtasks refiner")
 
 	restoreChain := func(msgChain json.RawMessage) ([]llms.MessageContent, error) {
 		var msgList []llms.MessageContent
@@ -200,7 +211,7 @@ func (fp *flowProvider) performSubtasksRefiner(
 		systemSection.Header.SystemMessage = &systemMessage
 		humanMessage := llms.TextParts(llms.ChatMessageTypeHuman, userRefinerTmpl)
 		systemSection.Header.HumanMessage = &humanMessage
-		// remove the last report with subtasks list
+		// remove the last report with subtasks list/patch
 		for idx := len(systemSection.Body) - 1; idx >= 0; idx-- {
 			if systemSection.Body[idx].Type == cast.RequestResponse {
 				systemSection.Body = systemSection.Body[:idx]
@@ -258,21 +269,28 @@ func (fp *flowProvider) performSubtasksRefiner(
 		return nil, fmt.Errorf("failed to get searcher handler: %w", err)
 	}
 
-	cfg := tools.GeneratorExecutorConfig{
+	cfg := tools.RefinerExecutorConfig{
 		TaskID:   taskID,
 		Memorist: memorist,
 		Searcher: searcher,
-		SubtaskList: func(ctx context.Context, name string, args json.RawMessage) (string, error) {
-			err := json.Unmarshal(args, &subtaskList)
-			if err != nil {
-				return "", fmt.Errorf("failed to unmarshal subtask list: %w", err)
+		SubtaskPatch: func(ctx context.Context, name string, args json.RawMessage) (string, error) {
+			logger.WithField("args_len", len(args)).Debug("received subtask patch")
+			if err := json.Unmarshal(args, &subtaskPatch); err != nil {
+				logger.WithError(err).Error("failed to unmarshal subtask patch")
+				return "", fmt.Errorf("failed to unmarshal subtask patch: %w", err)
 			}
-			return "subtask list successfully processed", nil
+			if err := ValidateSubtaskPatch(subtaskPatch); err != nil {
+				logger.WithError(err).Error("invalid subtask patch")
+				return "", fmt.Errorf("invalid subtask patch: %w", err)
+			}
+			logger.WithField("operations_count", len(subtaskPatch.Operations)).Debug("subtask patch validated")
+			return "subtask patch successfully processed", nil
 		},
 	}
-	executor, err := fp.executor.GetGeneratorExecutor(cfg)
+	executor, err := fp.executor.GetRefinerExecutor(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get generator executor: %w", err)
+		logger.WithError(err).Error("failed to get refiner executor")
+		return nil, fmt.Errorf("failed to get refiner executor: %w", err)
 	}
 
 	chainBlob, err := json.Marshal(chain)
@@ -289,14 +307,31 @@ func (fp *flowProvider) performSubtasksRefiner(
 		TaskID:        database.Int64ToNullInt64(&taskID),
 	})
 	if err != nil {
+		logger.WithError(err).Error("failed to create msg chain")
 		return nil, fmt.Errorf("failed to create msg chain: %w", err)
 	}
+
+	logger.WithField("msg_chain_id", msgChain.ID).Debug("created msg chain for refiner")
 
 	ctx = tools.PutAgentContext(ctx, msgChainType)
 	err = fp.performAgentChain(ctx, optAgentType, msgChain.ID, &taskID, nil, chain, executor, fp.summarizer)
 	if err != nil {
+		logger.WithError(err).Error("failed to perform subtasks refiner agent chain")
 		return nil, fmt.Errorf("failed to get subtasks refiner result: %w", err)
 	}
+
+	// Apply the patch operations to the planned subtasks
+	result, err := applySubtaskOperations(plannedSubtasks, subtaskPatch, logger)
+	if err != nil {
+		logger.WithError(err).Error("failed to apply subtask operations")
+		return nil, fmt.Errorf("failed to apply subtask operations: %w", err)
+	}
+
+	logger.WithFields(logrus.Fields{
+		"input_count":  len(plannedSubtasks),
+		"output_count": len(result),
+		"operations":   len(subtaskPatch.Operations),
+	}).Debug("successfully applied subtask patch")
 
 	if agentCtx, ok := tools.GetAgentContext(ctx); ok {
 		fp.agentLog.PutLog(
@@ -304,13 +339,13 @@ func (fp *flowProvider) performSubtasksRefiner(
 			agentCtx.ParentAgentType,
 			agentCtx.CurrentAgentType,
 			input,
-			fp.subtasksToMarkdown(subtaskList.Subtasks),
+			fp.subtasksToMarkdown(result),
 			&taskID,
 			nil,
 		)
 	}
 
-	return subtaskList.Subtasks, nil
+	return result, nil
 }
 
 func (fp *flowProvider) performCoder(

--- a/backend/pkg/providers/provider.go
+++ b/backend/pkg/providers/provider.go
@@ -296,6 +296,11 @@ func (fp *flowProvider) RefineSubtasks(ctx context.Context, taskID int64) ([]too
 
 	subtasksInfo := fp.getSubtasksInfo(taskID, tasksInfo.Subtasks)
 
+	logger.WithFields(logrus.Fields{
+		"planned_count":   len(subtasksInfo.Planned),
+		"completed_count": len(subtasksInfo.Completed),
+	}).Debug("retrieved subtasks info for refinement")
+
 	refinerContext := map[string]map[string]any{
 		"user": {
 			"Task":              tasksInfo.Task,
@@ -304,6 +309,7 @@ func (fp *flowProvider) RefineSubtasks(ctx context.Context, taskID int64) ([]too
 			"CompletedSubtasks": subtasksInfo.Completed,
 		},
 		"system": {
+			"SubtaskPatchToolName":    tools.SubtaskPatchToolName,
 			"SubtaskListToolName":     tools.SubtaskListToolName,
 			"SearchToolName":          tools.SearchToolName,
 			"TerminalToolName":        tools.TerminalToolName,
@@ -368,7 +374,7 @@ func (fp *flowProvider) RefineSubtasks(ctx context.Context, taskID int64) ([]too
 		return nil, wrapErrorEndSpan(ctx, refinerSpan, "failed to get task system refiner template", err)
 	}
 
-	subtasks, err := fp.performSubtasksRefiner(ctx, taskID, systemRefinerTmpl, refinerTmpl, tasksInfo.Task.Input)
+	subtasks, err := fp.performSubtasksRefiner(ctx, taskID, subtasksInfo.Planned, systemRefinerTmpl, refinerTmpl, tasksInfo.Task.Input)
 	if err != nil {
 		return nil, wrapErrorEndSpan(ctx, refinerSpan, "failed to perform subtasks refiner", err)
 	}

--- a/backend/pkg/providers/subtask_patch.go
+++ b/backend/pkg/providers/subtask_patch.go
@@ -1,0 +1,249 @@
+package providers
+
+import (
+	"fmt"
+	"slices"
+
+	"pentagi/pkg/database"
+	"pentagi/pkg/tools"
+
+	"github.com/sirupsen/logrus"
+)
+
+// applySubtaskOperations applies delta operations to the current planned subtasks
+// and returns the updated list of SubtaskInfo. Operations are applied in order.
+// Returns an error if any operation has missing required fields.
+func applySubtaskOperations(
+	planned []database.Subtask,
+	patch tools.SubtaskPatch,
+	logger *logrus.Entry,
+) ([]tools.SubtaskInfo, error) {
+	logger.WithFields(logrus.Fields{
+		"planned_count":    len(planned),
+		"operations_count": len(patch.Operations),
+		"message":          patch.Message,
+	}).Debug("applying subtask operations")
+
+	// Convert database.Subtask to tools.SubtaskInfo with IDs
+	result := make([]tools.SubtaskInfo, 0, len(planned))
+	for _, st := range planned {
+		result = append(result, tools.SubtaskInfo{
+			ID:          st.ID,
+			Title:       st.Title,
+			Description: st.Description,
+		})
+	}
+
+	// Build ID -> index map for position lookups
+	idToIdx := buildIndexMap(result)
+
+	// Track removals separately to avoid modifying the slice during iteration
+	removed := make(map[int64]bool)
+
+	// First pass: process removals and modifications in-place
+	for i, op := range patch.Operations {
+		opLogger := logger.WithFields(logrus.Fields{
+			"operation_index": i,
+			"operation":       op.Op,
+			"id":              op.ID,
+			"after_id":        op.AfterID,
+		})
+
+		switch op.Op {
+		case tools.SubtaskOpRemove:
+			if op.ID == nil {
+				err := fmt.Errorf("operation %d: remove operation missing required id field", i)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+			if _, ok := idToIdx[*op.ID]; !ok {
+				err := fmt.Errorf("operation %d: subtask with id %d not found for removal", i, *op.ID)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+			removed[*op.ID] = true
+			opLogger.WithField("subtask_id", *op.ID).Debug("marked subtask for removal")
+
+		case tools.SubtaskOpModify:
+			if op.ID == nil {
+				err := fmt.Errorf("operation %d: modify operation missing required id field", i)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+			if op.Title == "" && op.Description == "" {
+				err := fmt.Errorf("operation %d: modify operation missing both title and description fields", i)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+			idx, ok := idToIdx[*op.ID]
+			if !ok {
+				err := fmt.Errorf("operation %d: subtask with id %d not found for modification", i, *op.ID)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+			// Only update fields that are provided
+			if op.Title != "" {
+				result[idx].Title = op.Title
+				opLogger.WithField("new_title", op.Title).Debug("updated subtask title")
+			}
+			if op.Description != "" {
+				result[idx].Description = op.Description
+				opLogger.WithField("new_description_len", len(op.Description)).Debug("updated subtask description")
+			}
+		}
+	}
+
+	// Build result list (excluding removed subtasks)
+	if len(removed) > 0 {
+		filtered := make([]tools.SubtaskInfo, 0, len(result)-len(removed))
+		for _, st := range result {
+			if !removed[st.ID] {
+				filtered = append(filtered, st)
+			}
+		}
+		result = filtered
+		logger.WithField("removed_count", len(removed)).Debug("filtered out removed subtasks")
+	}
+
+	// Rebuild index map for the filtered result
+	idToIdx = buildIndexMap(result)
+
+	// Second pass: process adds and reorders with position awareness
+	for i, op := range patch.Operations {
+		opLogger := logger.WithFields(logrus.Fields{
+			"operation_index": i,
+			"operation":       op.Op,
+			"id":              op.ID,
+			"after_id":        op.AfterID,
+		})
+
+		switch op.Op {
+		case tools.SubtaskOpAdd:
+			if op.Title == "" {
+				err := fmt.Errorf("operation %d: add operation missing required title field", i)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+			if op.Description == "" {
+				err := fmt.Errorf("operation %d: add operation missing required description field", i)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+
+			newSubtask := tools.SubtaskInfo{
+				ID:          0, // New subtasks don't have an ID yet
+				Title:       op.Title,
+				Description: op.Description,
+			}
+
+			insertIdx := calculateInsertIndex(op.AfterID, idToIdx, len(result))
+			result = slices.Insert(result, insertIdx, newSubtask)
+
+			// Rebuild index map after insertion
+			idToIdx = buildIndexMap(result)
+
+			opLogger.WithFields(logrus.Fields{
+				"insert_idx": insertIdx,
+				"title":      op.Title,
+			}).Debug("inserted new subtask")
+
+		case tools.SubtaskOpReorder:
+			if op.ID == nil {
+				err := fmt.Errorf("operation %d: reorder operation missing required id field", i)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+
+			currentIdx, ok := idToIdx[*op.ID]
+			if !ok {
+				err := fmt.Errorf("operation %d: subtask with id %d not found for reorder", i, *op.ID)
+				opLogger.Error(err.Error())
+				return nil, err
+			}
+
+			// Remove from current position
+			subtaskToMove := result[currentIdx]
+			result = slices.Delete(result, currentIdx, currentIdx+1)
+
+			// Rebuild index map after deletion
+			idToIdx = buildIndexMap(result)
+
+			// Calculate new position and insert
+			insertIdx := calculateInsertIndex(op.AfterID, idToIdx, len(result))
+			result = slices.Insert(result, insertIdx, subtaskToMove)
+
+			// Rebuild index map after insertion
+			idToIdx = buildIndexMap(result)
+
+			opLogger.WithFields(logrus.Fields{
+				"from_idx": currentIdx,
+				"to_idx":   insertIdx,
+			}).Debug("reordered subtask")
+		}
+	}
+
+	logger.WithFields(logrus.Fields{
+		"final_count":   len(result),
+		"initial_count": len(planned),
+	}).Debug("completed applying subtask operations")
+
+	return result, nil
+}
+
+// buildIndexMap creates a map from subtask ID to its index in the slice
+func buildIndexMap(subtasks []tools.SubtaskInfo) map[int64]int {
+	idToIdx := make(map[int64]int, len(subtasks))
+	for i, st := range subtasks {
+		if st.ID != 0 {
+			idToIdx[st.ID] = i
+		}
+	}
+	return idToIdx
+}
+
+// calculateInsertIndex determines the insertion index based on afterID
+func calculateInsertIndex(afterID *int64, idToIdx map[int64]int, length int) int {
+	if afterID == nil || *afterID == 0 {
+		return 0 // Insert at beginning
+	}
+
+	if idx, ok := idToIdx[*afterID]; ok {
+		return idx + 1 // Insert after the referenced subtask
+	}
+
+	// AfterID not found, append to end
+	return length
+}
+
+// ValidateSubtaskPatch validates the operations in a SubtaskPatch
+func ValidateSubtaskPatch(patch tools.SubtaskPatch) error {
+	for i, op := range patch.Operations {
+		switch op.Op {
+		case tools.SubtaskOpAdd:
+			if op.Title == "" {
+				return fmt.Errorf("operation %d: add requires title", i)
+			}
+			if op.Description == "" {
+				return fmt.Errorf("operation %d: add requires description", i)
+			}
+		case tools.SubtaskOpRemove:
+			if op.ID == nil {
+				return fmt.Errorf("operation %d: remove requires id", i)
+			}
+		case tools.SubtaskOpModify:
+			if op.ID == nil {
+				return fmt.Errorf("operation %d: modify requires id", i)
+			}
+			if op.Title == "" && op.Description == "" {
+				return fmt.Errorf("operation %d: modify requires at least title or description", i)
+			}
+		case tools.SubtaskOpReorder:
+			if op.ID == nil {
+				return fmt.Errorf("operation %d: reorder requires id", i)
+			}
+		default:
+			return fmt.Errorf("operation %d: unknown operation type %q", i, op.Op)
+		}
+	}
+	return nil
+}

--- a/backend/pkg/providers/subtask_patch_test.go
+++ b/backend/pkg/providers/subtask_patch_test.go
@@ -1,0 +1,679 @@
+package providers
+
+import (
+	"io"
+	"testing"
+
+	"pentagi/pkg/database"
+	"pentagi/pkg/tools"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger() *logrus.Entry {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	return logrus.NewEntry(logger)
+}
+
+func TestApplySubtaskOperations_EmptyPatch(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+		{ID: 3, Title: "Task 3", Description: "Description 3"},
+	}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{},
+		Message:    "No changes needed",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, int64(1), result[0].ID)
+	assert.Equal(t, "Task 1", result[0].Title)
+	assert.Equal(t, int64(2), result[1].ID)
+	assert.Equal(t, int64(3), result[2].ID)
+}
+
+func TestApplySubtaskOperations_RemoveOperation(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+		{ID: 3, Title: "Task 3", Description: "Description 3"},
+	}
+
+	id2 := int64(2)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpRemove, ID: &id2},
+		},
+		Message: "Removed task 2",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(1), result[0].ID)
+	assert.Equal(t, int64(3), result[1].ID)
+}
+
+func TestApplySubtaskOperations_RemoveMultiple(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+		{ID: 3, Title: "Task 3", Description: "Description 3"},
+		{ID: 4, Title: "Task 4", Description: "Description 4"},
+	}
+
+	id1, id3 := int64(1), int64(3)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpRemove, ID: &id1},
+			{Op: tools.SubtaskOpRemove, ID: &id3},
+		},
+		Message: "Removed tasks 1 and 3",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), result[0].ID)
+	assert.Equal(t, int64(4), result[1].ID)
+}
+
+func TestApplySubtaskOperations_RemoveNonExistent(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	id99 := int64(99)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpRemove, ID: &id99},
+		},
+		Message: "Try to remove non-existent task",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found for removal")
+}
+
+func TestApplySubtaskOperations_ModifyTitle(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+	}
+
+	id1 := int64(1)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpModify, ID: &id1, Title: "Updated Task 1"},
+		},
+		Message: "Updated title",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 2)
+	assert.Equal(t, "Updated Task 1", result[0].Title)
+	assert.Equal(t, "Description 1", result[0].Description) // Description unchanged
+	assert.Equal(t, "Task 2", result[1].Title)              // Other task unchanged
+}
+
+func TestApplySubtaskOperations_ModifyDescription(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	id1 := int64(1)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpModify, ID: &id1, Description: "New Description"},
+		},
+		Message: "Updated description",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Task 1", result[0].Title)              // Title unchanged
+	assert.Equal(t, "New Description", result[0].Description)
+}
+
+func TestApplySubtaskOperations_ModifyBoth(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	id1 := int64(1)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpModify, ID: &id1, Title: "New Title", Description: "New Description"},
+		},
+		Message: "Updated both",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "New Title", result[0].Title)
+	assert.Equal(t, "New Description", result[0].Description)
+}
+
+func TestApplySubtaskOperations_AddAtBeginning(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+	}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpAdd, Title: "New Task", Description: "New Description"},
+		},
+		Message: "Added at beginning",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, int64(0), result[0].ID) // New task has ID 0
+	assert.Equal(t, "New Task", result[0].Title)
+	assert.Equal(t, int64(1), result[1].ID)
+	assert.Equal(t, int64(2), result[2].ID)
+}
+
+func TestApplySubtaskOperations_AddAfterSpecific(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+		{ID: 3, Title: "Task 3", Description: "Description 3"},
+	}
+
+	afterID := int64(1)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpAdd, AfterID: &afterID, Title: "New Task", Description: "New Description"},
+		},
+		Message: "Added after task 1",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 4)
+	assert.Equal(t, int64(1), result[0].ID)
+	assert.Equal(t, "New Task", result[1].Title)
+	assert.Equal(t, int64(2), result[2].ID)
+	assert.Equal(t, int64(3), result[3].ID)
+}
+
+func TestApplySubtaskOperations_AddAfterNonExistent(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	afterID := int64(99)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpAdd, AfterID: &afterID, Title: "New Task", Description: "New Description"},
+		},
+		Message: "Added after non-existent",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	// Should append to end when AfterID not found
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(1), result[0].ID)
+	assert.Equal(t, "New Task", result[1].Title)
+}
+
+func TestApplySubtaskOperations_ReorderToBeginning(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+		{ID: 3, Title: "Task 3", Description: "Description 3"},
+	}
+
+	id3 := int64(3)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpReorder, ID: &id3}, // AfterID nil = move to beginning
+		},
+		Message: "Moved task 3 to beginning",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, int64(3), result[0].ID)
+	assert.Equal(t, int64(1), result[1].ID)
+	assert.Equal(t, int64(2), result[2].ID)
+}
+
+func TestApplySubtaskOperations_ReorderAfterSpecific(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+		{ID: 3, Title: "Task 3", Description: "Description 3"},
+	}
+
+	id1, afterID := int64(1), int64(2)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpReorder, ID: &id1, AfterID: &afterID},
+		},
+		Message: "Moved task 1 after task 2",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, int64(2), result[0].ID)
+	assert.Equal(t, int64(1), result[1].ID)
+	assert.Equal(t, int64(3), result[2].ID)
+}
+
+func TestApplySubtaskOperations_ComplexScenario(t *testing.T) {
+	// Simulates a real refiner scenario:
+	// - Remove completed subtask
+	// - Modify an existing subtask based on findings
+	// - Add a new subtask to address a newly discovered issue
+	planned := []database.Subtask{
+		{ID: 10, Title: "Scan ports", Description: "Scan target ports"},
+		{ID: 11, Title: "Enumerate services", Description: "Enumerate running services"},
+		{ID: 12, Title: "Test vulnerabilities", Description: "Test for known vulnerabilities"},
+	}
+
+	id10, id11, afterID := int64(10), int64(11), int64(11)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpRemove, ID: &id10},
+			{Op: tools.SubtaskOpModify, ID: &id11, Description: "Enumerate services, focusing on web services found on port 80 and 443"},
+			{Op: tools.SubtaskOpAdd, AfterID: &afterID, Title: "Check for SQL injection", Description: "Test web forms for SQL injection vulnerabilities"},
+		},
+		Message: "Refined plan based on port scan results",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+
+	// First should be modified enumerate services
+	assert.Equal(t, int64(11), result[0].ID)
+	assert.Equal(t, "Enumerate services", result[0].Title)
+	assert.Contains(t, result[0].Description, "port 80 and 443")
+
+	// Second should be the new SQL injection task
+	assert.Equal(t, int64(0), result[1].ID) // New task
+	assert.Equal(t, "Check for SQL injection", result[1].Title)
+
+	// Third should be the original vulnerability test
+	assert.Equal(t, int64(12), result[2].ID)
+}
+
+func TestApplySubtaskOperations_RemoveAllTasks(t *testing.T) {
+	// Simulates task completion - all remaining subtasks are removed
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+		{ID: 2, Title: "Task 2", Description: "Description 2"},
+	}
+
+	id1, id2 := int64(1), int64(2)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpRemove, ID: &id1},
+			{Op: tools.SubtaskOpRemove, ID: &id2},
+		},
+		Message: "Task completed, removing all remaining subtasks",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 0)
+}
+
+func TestApplySubtaskOperations_EmptyPlanned(t *testing.T) {
+	planned := []database.Subtask{}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpAdd, Title: "New Task", Description: "Description"},
+		},
+		Message: "Adding first task",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "New Task", result[0].Title)
+}
+
+func TestApplySubtaskOperations_RemoveMissingID(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpRemove}, // Missing ID
+		},
+		Message: "Remove with missing ID",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remove operation missing required id field")
+}
+
+func TestApplySubtaskOperations_ModifyMissingID(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpModify, Title: "New Title"}, // Missing ID
+		},
+		Message: "Modify with missing ID",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "modify operation missing required id field")
+}
+
+func TestApplySubtaskOperations_ModifyMissingTitleAndDescription(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	id1 := int64(1)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpModify, ID: &id1}, // Missing both title and description
+		},
+		Message: "Modify with missing title and description",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "modify operation missing both title and description")
+}
+
+func TestApplySubtaskOperations_ModifyNonExistent(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	id99 := int64(99)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpModify, ID: &id99, Title: "New Title"},
+		},
+		Message: "Modify non-existent task",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found for modification")
+}
+
+func TestApplySubtaskOperations_AddMissingTitle(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpAdd, Description: "Some description"}, // Missing title
+		},
+		Message: "Add with missing title",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add operation missing required title field")
+}
+
+func TestApplySubtaskOperations_AddMissingDescription(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpAdd, Title: "New Task"}, // Missing description
+		},
+		Message: "Add with missing description",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add operation missing required description field")
+}
+
+func TestApplySubtaskOperations_ReorderMissingID(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpReorder}, // Missing ID
+		},
+		Message: "Reorder with missing ID",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reorder operation missing required id field")
+}
+
+func TestApplySubtaskOperations_ReorderNonExistent(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	id99 := int64(99)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpReorder, ID: &id99},
+		},
+		Message: "Reorder non-existent task",
+	}
+
+	_, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found for reorder")
+}
+
+func TestApplySubtaskOperations_MultipleAddsWithPositioning(t *testing.T) {
+	planned := []database.Subtask{
+		{ID: 1, Title: "Task 1", Description: "Description 1"},
+	}
+
+	afterID1 := int64(1)
+	patch := tools.SubtaskPatch{
+		Operations: []tools.SubtaskOperation{
+			{Op: tools.SubtaskOpAdd, Title: "Task A", Description: "Desc A"},
+			{Op: tools.SubtaskOpAdd, AfterID: &afterID1, Title: "Task B", Description: "Desc B"},
+		},
+		Message: "Multiple adds",
+	}
+
+	result, err := applySubtaskOperations(planned, patch, newTestLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, result, 3)
+	// Task A at beginning
+	assert.Equal(t, "Task A", result[0].Title)
+	// Task 1 in middle
+	assert.Equal(t, int64(1), result[1].ID)
+	// Task B after Task 1
+	assert.Equal(t, "Task B", result[2].Title)
+}
+
+func TestValidateSubtaskPatch_ValidOperations(t *testing.T) {
+	id := int64(1)
+
+	tests := []struct {
+		name  string
+		patch tools.SubtaskPatch
+	}{
+		{
+			name: "empty operations",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{},
+			},
+		},
+		{
+			name: "valid add",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpAdd, Title: "Title", Description: "Desc"},
+				},
+			},
+		},
+		{
+			name: "valid remove",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpRemove, ID: &id},
+				},
+			},
+		},
+		{
+			name: "valid modify with title",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpModify, ID: &id, Title: "New Title"},
+				},
+			},
+		},
+		{
+			name: "valid modify with description",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpModify, ID: &id, Description: "New Desc"},
+				},
+			},
+		},
+		{
+			name: "valid reorder",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpReorder, ID: &id},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSubtaskPatch(tt.patch)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateSubtaskPatch_InvalidOperations(t *testing.T) {
+	id := int64(1)
+
+	tests := []struct {
+		name          string
+		patch         tools.SubtaskPatch
+		expectedError string
+	}{
+		{
+			name: "add missing title",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpAdd, Description: "Desc"},
+				},
+			},
+			expectedError: "add requires title",
+		},
+		{
+			name: "add missing description",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpAdd, Title: "Title"},
+				},
+			},
+			expectedError: "add requires description",
+		},
+		{
+			name: "remove missing id",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpRemove},
+				},
+			},
+			expectedError: "remove requires id",
+		},
+		{
+			name: "modify missing id",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpModify, Title: "Title"},
+				},
+			},
+			expectedError: "modify requires id",
+		},
+		{
+			name: "modify missing both title and description",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpModify, ID: &id},
+				},
+			},
+			expectedError: "modify requires at least title or description",
+		},
+		{
+			name: "reorder missing id",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: tools.SubtaskOpReorder},
+				},
+			},
+			expectedError: "reorder requires id",
+		},
+		{
+			name: "unknown operation type",
+			patch: tools.SubtaskPatch{
+				Operations: []tools.SubtaskOperation{
+					{Op: "invalid_op"},
+				},
+			},
+			expectedError: "unknown operation type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSubtaskPatch(tt.patch)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+

--- a/backend/pkg/templates/prompts/refiner.tmpl
+++ b/backend/pkg/templates/prompts/refiner.tmpl
@@ -4,7 +4,7 @@ You are a specialized AI agent responsible for dynamically refining and optimizi
 
 ## CORE RESPONSIBILITY
 
-Your ONLY job is to analyze the results of completed subtasks and the current plan, then create an improved list of remaining subtasks (maximum {{.N}}). You MUST use the "{{.SubtaskListToolName}}" tool to submit your final refined list.
+Your ONLY job is to analyze the results of completed subtasks and the current plan, then submit **operations** to modify the current subtask list (maximum {{.N}} planned subtasks after modifications). You MUST use the "{{.SubtaskPatchToolName}}" tool to submit your refinement operations.
 
 ## EXECUTION ENVIRONMENT
 
@@ -167,12 +167,45 @@ Each refined subtask MUST:
 - Use research findings to inform the selection of the most promising solution path
 - Prioritize concrete experimentation over excessive theoretical research
 
+## OUTPUT FORMAT: DELTA OPERATIONS
+
+Instead of regenerating all subtasks, submit ONLY the changes needed using the "{{.SubtaskPatchToolName}}" tool.
+
+**Available Operations:**
+- `add`: Create a new subtask at a specific position
+  - Requires: `title`, `description`
+  - Optional: `after_id` (insert after this subtask ID; null/0 = insert at beginning)
+- `remove`: Delete a subtask by ID
+  - Requires: `id` (the subtask ID to remove)
+- `modify`: Update title and/or description of existing subtask
+  - Requires: `id` (the subtask ID to modify)
+  - Optional: `title`, `description` (only provided fields are updated)
+- `reorder`: Move a subtask to a different position
+  - Requires: `id` (the subtask ID to move)
+  - Optional: `after_id` (move after this subtask ID; null/0 = move to beginning)
+
+**Task Completion:**
+To signal that the task is complete, remove all remaining planned subtasks.
+
+**Examples:**
+- Remove completed subtask 42, add a new one after subtask 45:
+  `[{"op": "remove", "id": 42}, {"op": "add", "after_id": 45, "title": "...", "description": "..."}]`
+  
+- Modify subtask 43's description based on new findings:
+  `[{"op": "modify", "id": 43, "description": "Updated approach: ..."}]`
+
+- No changes needed (current plan is optimal):
+  `[]` (empty operations array)
+
+- Task complete (remove all remaining planned subtasks):
+  `[{"op": "remove", "id": 43}, {"op": "remove", "id": 44}, {"op": "remove", "id": 45}]`
+
 ## OUTPUT REQUIREMENTS
 
-You MUST complete your refinement by using the "{{.SubtaskListToolName}}" tool with:
-- An updated list of remaining subtasks meeting the above requirements (or an empty list if the task is complete)
-- A clear explanatory message summarizing progress and plan changes
-- Justification for any significant modifications to the subtask list
+You MUST complete your refinement by using the "{{.SubtaskPatchToolName}}" tool with:
+- A list of operations to apply to the current subtask list (or empty array if no changes needed)
+- A clear explanatory message summarizing progress and changes made
+- Justification for any significant modifications
 - Brief analysis of completed tasks' outcomes and how they inform the refined plan
 
 {{.ToolPlaceholder}}

--- a/backend/pkg/templates/templates.go
+++ b/backend/pkg/templates/templates.go
@@ -237,7 +237,7 @@ var PromptVariables = map[PromptType][]string{
 		"Subtasks",
 	},
 	PromptTypeRefiner: {
-		"SubtaskListToolName",
+		"SubtaskPatchToolName",
 		"SearchToolName",
 		"TerminalToolName",
 		"FileToolName",

--- a/backend/pkg/templates/validator/testdata.go
+++ b/backend/pkg/templates/validator/testdata.go
@@ -57,6 +57,7 @@ func CreateDummyTemplateData() map[string]any {
 		"EnricherResultToolName":    tools.EnricherResultToolName,
 		"ReportResultToolName":      tools.ReportResultToolName,
 		"SubtaskListToolName":       tools.SubtaskListToolName,
+		"SubtaskPatchToolName":      tools.SubtaskPatchToolName,
 		"AskUserToolName":           tools.AskUserToolName,
 
 		// Summarization related - using constants from proper packages

--- a/backend/pkg/tools/registry.go
+++ b/backend/pkg/tools/registry.go
@@ -40,6 +40,7 @@ const (
 	GraphitiSearchToolName    = "graphiti_search"
 	ReportResultToolName      = "report_result"
 	SubtaskListToolName       = "subtask_list"
+	SubtaskPatchToolName      = "subtask_patch"
 	TerminalToolName          = "terminal"
 	FileToolName              = "file"
 )
@@ -89,6 +90,7 @@ var toolsTypeMapping = map[string]ToolType{
 	GraphitiSearchToolName:    SearchVectorDbToolType,
 	ReportResultToolName:      StoreAgentResultToolType,
 	SubtaskListToolName:       StoreAgentResultToolType,
+	SubtaskPatchToolName:      StoreAgentResultToolType,
 	TerminalToolName:          EnvironmentToolType,
 	FileToolName:              EnvironmentToolType,
 }
@@ -140,6 +142,13 @@ var registryDefinitions = map[string]llms.FunctionDefinition{
 		Name:        SubtaskListToolName,
 		Description: "Send new generated subtask list to the user",
 		Parameters:  reflector.Reflect(&SubtaskList{}),
+	},
+	SubtaskPatchToolName: {
+		Name: SubtaskPatchToolName,
+		Description: "Submit delta operations to modify the current subtask list instead of regenerating all subtasks. " +
+			"Supports add (create new subtask at position), remove (delete by ID), modify (update title/description), " +
+			"and reorder (move to different position) operations. Use empty operations array if no changes needed.",
+		Parameters: reflector.Reflect(&SubtaskPatch{}),
 	},
 	SearchToolName: {
 		Name: SearchToolName,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -271,7 +271,7 @@ services:
       - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD:-devpassword}
-      - MODEL_NAME=${GRAPHITI_MODEL_NAME:-gpt-5}
+      - MODEL_NAME=${GRAPHITI_MODEL_NAME:-gpt-5-mini}
       # NOTE(@todo zavgorodnii): currently graphiti server only works with OpenAI LLM backend
       - OPENAI_BASE_URL=${OPEN_AI_SERVER_URL:-https://api.openai.com/v1}
       - OPENAI_API_KEY=${OPEN_AI_KEY:-}


### PR DESCRIPTION
### Description of the Change

#### Problem

The current subtask refiner regenerates the entire subtask list on each refinement cycle, which is **token inefficient** - Requires the LLM to output all subtasks even when only minor changes are needed.

#### Solution

Implement a **delta-based patch system** for subtask refinement that allows the refiner to submit only the changes needed rather than regenerating the complete list.

**Key changes:**
- Introduced `SubtaskPatch` with four operation types: `add`, `remove`, `modify`, and `reorder`
- Each operation targets specific subtasks by ID for precise modifications
- Added `applySubtaskOperations()` function to apply patch operations to the existing subtask list
- Updated refiner prompt to instruct the LLM to use delta operations
- Created dedicated `GetRefinerExecutor()` with the new `subtask_patch` tool
- Added comprehensive validation and error handling for patch operations
- Increased refiner max_tokens from 8192 to 16384 for complex refinement scenarios

**Additional optimizations:**
- Changed default Graphiti model from `gpt-5` to `gpt-5-mini`