### PR TITLE
fix: validate required fields in OAuth state parser

### DIFF
--- a/backend/pkg/server/services/auth.go
+++ b/backend/pkg/server/services/auth.go
@@ -633,7 +633,22 @@ func (s *AuthService) parseState(c *gin.Context, state string) (map[string]strin
 		return nil, err
 	}
 
-	exp, err := strconv.ParseInt(stateData["exp"], 10, 64)
+	expStr, ok := stateData["exp"]
+	if !ok || expStr == "" {
+		err := fmt.Errorf("missing required field: exp")
+		logger.FromContext(c).WithError(err).Errorf("error on validating state data")
+		response.Error(c, response.ErrAuthInvalidAuthorizationState, err)
+		return nil, err
+	}
+
+	if _, ok := stateData["provider"]; !ok {
+		err := fmt.Errorf("missing required field: provider")
+		logger.FromContext(c).WithError(err).Errorf("error on validating state data")
+		response.Error(c, response.ErrAuthInvalidAuthorizationState, err)
+		return nil, err
+	}
+
+	exp, err := strconv.ParseInt(expStr, 10, 64)
 	if err != nil {
 		logger.FromContext(c).WithError(err).Errorf("error on parsing expiration time")
 		response.Error(c, response.ErrAuthInvalidAuthorizationState, err)


### PR DESCRIPTION
### Description of the Change

#### Problem

The `parseState()` function in `auth.go` accesses `stateData["exp"]` and `stateData["provider"]` without first checking whether these keys exist in the map. While Go map access on missing keys returns the zero value (empty string) rather than panicking, this produces misleading error messages:

- Missing `exp`: `strconv.ParseInt("")` fails with "invalid syntax" instead of clearly indicating the field is absent
- Missing `provider`: empty string is used as a provider key, resulting in a confusing "provider not initialized" error in `authLoginCallback()`

If the HMAC signing key were ever compromised or a signing bug introduced, crafted state payloads with missing fields would produce confusing errors that complicate incident response.

#### Solution

Add explicit existence checks for required fields (`exp` and `provider`) immediately after JSON unmarshalling in `parseState()`. Each missing field now returns a clear, specific error message (e.g., "missing required field: exp") with proper logging.

This is a defense-in-depth measure that ensures:
1. Clear error messages for each specific missing field
2. Early validation before downstream usage
3. Consistent error handling pattern with the rest of the function

Ref: #101 (item 8)

### Type of Change

- [x] 🛡️ Security update

### Areas Affected

- [x] Core Services (Frontend UI/Backend API)

### Testing and Verification

#### Test Steps
1. Build the backend: `cd backend && go build ./...`
2. Run existing tests: `go test ./pkg/server/services/...`
3. Verify that valid OAuth flows still work normally
4. Verify that crafted states with missing `exp` or `provider` fields return clear error messages

### Security Considerations

This change hardens the OAuth state parser against malformed state data. While the state is HMAC-signed (preventing tampering under normal conditions), this defense-in-depth validation ensures clear error handling even if the signing mechanism is bypassed.

### Checklist

#### Code Quality
- [x] My code follows the project's coding standards
- [x] All new and existing tests pass
- [x] I have run `go fmt` and `go vet` (for Go code)

#### Security
- [x] I have considered security implications
- [x] Changes maintain or improve the security model

#### Compatibility
- [x] Changes are backward compatible