### PR TITLE
fix: add missing return after error in OAuth callback redirect

### DIFF
--- a/backend/pkg/server/services/auth.go
+++ b/backend/pkg/server/services/auth.go
@@ -588,6 +588,7 @@ func (s *AuthService) authLoginCallback(c *gin.Context, stateData map[string]str
 		u, err := url.Parse(returnURI)
 		if err != nil {
 			response.Success(c, http.StatusOK, nil)
+			return
 		}
 		query := u.Query()
 		query.Add("status", "success")


### PR DESCRIPTION
### Description of the Change

#### Problem

In `authLoginCallback()`, when `url.Parse(returnURI)` fails, `response.Success(c, http.StatusOK, nil)` writes a 200 OK response but execution falls through to line 592-595 which calls `http.Redirect()`, attempting to write a second response (303 See Other). This causes a "superfluous response.WriteHeader call" warning and undefined behavior from the double response write.

#### Solution

Add the missing `return` statement after `response.Success()` in the error branch to prevent execution from falling through to the redirect logic.

Ref: #101

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Areas Affected

- [x] Core Services (Frontend UI/Backend API)

### Testing and Verification

#### Test Steps
1. Build the backend: `cd backend && go build ./...`
2. Trigger OAuth login with a malformed `return_uri` in state data
3. Verify only one response is written (no "superfluous response.WriteHeader" in logs)

### Security Considerations

Without the `return`, a malformed `return_uri` could cause unpredictable HTTP response behavior. The fix ensures clean error handling in the OAuth callback flow.

### Checklist

#### Code Quality
- [x] My code follows the project's coding standards
- [x] All new and existing tests pass
- [x] I have run `go fmt` and `go vet` (for Go code)

#### Security
- [x] I have considered security implications
- [x] Changes maintain or improve the security model

#### Compatibility
- [x] Changes are backward compatible