### PR TITLE
chore(backend): fix docker client constant name typo

### DIFF
--- a/backend/pkg/docker/client.go
+++ b/backend/pkg/docker/client.go
@@ -34,7 +34,7 @@ const (
 	defaultImage                = "debian:latest"
 	defaultDockerSocketPath     = "/var/run/docker.sock"
 	containerPrimaryTypePattern = "-terminal-"
-	containeLocalCwdTemplate    = "flow-%d"
+	containerLocalCwdTemplate   = "flow-%d"
 	containerPortsNumber        = 2
 	limitContainerPortsNumber   = 2000
 )
@@ -163,14 +163,14 @@ func (dc *dockerClient) SpawnContainer(
 		return database.Container{}, fmt.Errorf("no config found for container %s", containerName)
 	}
 
-	workDir := filepath.Join(dc.dataDir, fmt.Sprintf(containeLocalCwdTemplate, flowID))
+	workDir := filepath.Join(dc.dataDir, fmt.Sprintf(containerLocalCwdTemplate, flowID))
 	if err := os.MkdirAll(workDir, 0755); err != nil {
 		return database.Container{}, fmt.Errorf("failed to create tmp directory: %w", err)
 	}
 
 	hostDir := dc.hostDir
 	if hostDir != "" {
-		hostDir = filepath.Join(hostDir, fmt.Sprintf(containeLocalCwdTemplate, flowID))
+		hostDir = filepath.Join(hostDir, fmt.Sprintf(containerLocalCwdTemplate, flowID))
 	}
 
 	logger := dc.logger.WithContext(ctx).WithFields(logrus.Fields{


### PR DESCRIPTION
### Description of the Change

#### Problem
A constant name in the docker client has a typo (`containeLocalCwdTemplate`), reducing readability and making searches/refactors harder.

#### Solution
Fix the typo by renaming it to `containerLocalCwdTemplate` and update all references.

Closes: N/A

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

### Areas Affected
- [x] Core Services (Frontend UI/Backend API)

### Testing and Verification

#### Test Steps
1. N/A (rename-only change, no behavior changes)

#### Test Results
N/A