### PR TITLE
fix: prevent goroutine leak in terminal exec timeout handling

### DIFF
--- a/backend/pkg/tools/terminal.go
+++ b/backend/pkg/tools/terminal.go
@@ -208,8 +208,6 @@ func (t *terminal) getExecResult(ctx context.Context, id string, timeout time.Du
 	if err != nil {
 		return "", fmt.Errorf("failed to attach to exec process: %w", err)
 	}
-	defer resp.Close()
-
 	dst := bytes.Buffer{}
 	done := make(chan struct{})
 	go func() {
@@ -219,7 +217,12 @@ func (t *terminal) getExecResult(ctx context.Context, id string, timeout time.Du
 
 	select {
 	case <-done:
+		resp.Close()
 	case <-ctx.Done():
+		// Close the connection first to unblock the io.Copy goroutine,
+		// then wait for it to finish to prevent a goroutine leak.
+		resp.Close()
+		<-done
 		result := fmt.Sprintf("temporary output: %s", dst.String())
 		err = fmt.Errorf("timeout value is too low, use greater value if you need so: %w: %s", ctx.Err(), result)
 	}


### PR DESCRIPTION
## Problem

When `getExecResult` times out via `ctx.Done()`, the function returns but leaves a goroutine blocked on `io.Copy(&dst, resp.Reader)`. The connection (`resp`) is only closed by `defer` after the function returns, but by that point the goroutine is already leaked — `io.Copy` may remain blocked even after `resp.Close()` because the close races with the blocked read.

Each timed-out command leaks one goroutine and its associated resources (#108).

## Fix

- Close `resp` **before** waiting for the goroutine on timeout, which unblocks `io.Copy`
- Wait for the goroutine (`<-done`) after closing to ensure clean shutdown
- On the normal path, close `resp` immediately after copy completes
- Remove `defer resp.Close()` since both paths now close explicitly

## Before

```
timeout → return → defer resp.Close() → goroutine still blocked on io.Copy
```

## After

```
timeout → resp.Close() → io.Copy returns → <-done → return (no leak)
```

Fixes #108