### PR TITLE
fix: add missing closing quote in GetUser swagger annotation

### DIFF
--- a/backend/pkg/server/services/users.go
+++ b/backend/pkg/server/services/users.go
@@ -278,7 +278,7 @@ func (s *UserService) GetUsers(c *gin.Context) {
 // @Produce json
 // @Param hash path string true "hash in hex format (md5)" minlength(32) maxlength(32)
 // @Success 200 {object} response.successResp{data=models.UserRolePrivileges} "user received successful"
-// @Failure 403 {object} response.errorResp "getting user not permitted
+// @Failure 403 {object} response.errorResp "getting user not permitted"
 // @Failure 404 {object} response.errorResp "user not found"
 // @Failure 500 {object} response.errorResp "internal error on getting user"
 // @Router /users/{hash} [get]


### PR DESCRIPTION
## Description of the Change

### Problem

The `@Failure 403` swagger comment for `GetUser` is missing the closing double-quote on its description string:

```go
// BEFORE
// @Failure 403 {object} response.errorResp "getting user not permitted
```

This causes malformed Swagger/OpenAPI documentation output.

### Solution

Add the missing closing quote:

```go
// AFTER
// @Failure 403 {object} response.errorResp "getting user not permitted"
```

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

### Areas Affected

- [x] Core Services (Frontend UI/Backend API)

### Testing and Verification

#### Test Steps
1. Run `swag init` — no longer produces a malformed annotation warning for this line
2. Generated Swagger JSON correctly includes the 403 description string

### Security Considerations

No security implications. Comment-only change.

### Checklist

#### Code Quality
- [x] My code follows the project's coding standards
- [x] All new and existing tests pass
- [x] I have run `go fmt` and `go vet` (for Go code)

#### Security
- [x] I have considered security implications
- [x] Changes maintain or improve the security model

#### Compatibility
- [x] Changes are backward compatible