### PR TITLE
fix: remove debug console.log statements from settings-prompt

### DIFF
--- a/frontend/src/pages/settings/settings-prompt.tsx
+++ b/frontend/src/pages/settings/settings-prompt.tsx
@@ -265,7 +265,6 @@ const SettingsPrompt = () => {
             }
 
             setResetDialogOpen(false);
-            console.log('Prompt reset to default successfully');
         } catch (error) {
             console.error('Reset error:', error);
             setSubmitError(error instanceof Error ? error.message : 'An error occurred while resetting');
@@ -534,7 +533,6 @@ const SettingsPrompt = () => {
 
         // For creation, check if the template is identical to the default
         if (!isUpdate && formData.template === promptInfo.defaultSystemTemplate) {
-            console.log('Template is identical to default, skipping save');
 
             return;
         }
@@ -562,7 +560,6 @@ const SettingsPrompt = () => {
                         template: formData.template,
                     },
                 });
-                console.log('System prompt updated successfully');
             } else {
                 // Create new user-defined prompt
                 await createPrompt({
@@ -572,7 +569,6 @@ const SettingsPrompt = () => {
                         type: promptType,
                     },
                 });
-                console.log('System prompt created successfully');
             }
         } catch (error) {
             console.error('Submit error:', error);
@@ -589,7 +585,6 @@ const SettingsPrompt = () => {
 
         // For creation, check if the template is identical to the default
         if (!isUpdate && formData.template === promptInfo.defaultHumanTemplate) {
-            console.log('Human template is identical to default, skipping save');
 
             return;
         }
@@ -616,7 +611,6 @@ const SettingsPrompt = () => {
                         template: formData.template,
                     },
                 });
-                console.log('Human prompt updated successfully');
             } else {
                 // Create new user-defined prompt
                 await createPrompt({
@@ -626,7 +620,6 @@ const SettingsPrompt = () => {
                         type: humanPromptType,
                     },
                 });
-                console.log('Human prompt created successfully');
             }
         } catch (error) {
             console.error('Submit error:', error);


### PR DESCRIPTION
## Description of the Change

### Problem

`settings-prompt.tsx` contains 7 leftover `console.log` calls on success paths that were introduced during development but should not be present in production code:

- `'Prompt reset to default successfully'`
- `'Template is identical to default, skipping save'`
- `'System prompt updated successfully'`
- `'System prompt created successfully'`
- `'Human template is identical to default, skipping save'`
- `'Human prompt updated successfully'`
- `'Human prompt created successfully'`

### Solution

Remove all 7 debug `console.log` statements. Error paths using `console.error` are intentionally kept.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Areas Affected

- [x] Core Services (Frontend UI/Backend API)

### Testing and Verification

#### Test Steps
1. Open browser DevTools console
2. Perform prompt reset, create, and update actions in Settings
3. Confirm no debug messages appear in console (only errors if they occur)

### Security Considerations

No security implications.

### Checklist

#### Code Quality
- [x] My code follows the project's coding standards
- [x] All new and existing tests pass
- [x] I have run `npm run prettier` and `npm run lint` (for TypeScript code)

#### Security
- [x] I have considered security implications
- [x] Changes maintain or improve the security model

#### Compatibility
- [x] Changes are backward compatible