### PR TITLE
fix: fix grammatically incorrect error messages in API tool handlers

### DIFF
--- a/backend/pkg/tools/perplexity.go
+++ b/backend/pkg/tools/perplexity.go
@@ -281,23 +281,23 @@ func (t *perplexity) handleErrorResponse(statusCode int) error {
 	case http.StatusBadRequest:
 		return errors.New("request is invalid")
 	case http.StatusUnauthorized:
-		return errors.New("API key is wrong")
+		return errors.New("API key is invalid")
 	case http.StatusForbidden:
 		return errors.New("the endpoint requested is hidden for administrators only")
 	case http.StatusNotFound:
 		return errors.New("the specified endpoint could not be found")
 	case http.StatusMethodNotAllowed:
-		return errors.New("there need to try to access an endpoint with an invalid method")
+		return errors.New("the endpoint does not allow this HTTP method")
 	case http.StatusTooManyRequests:
-		return errors.New("there are requesting too many results")
+		return errors.New("too many requests, please slow down")
 	case http.StatusInternalServerError:
-		return errors.New("there had a problem with our server. try again later")
+		return errors.New("the server encountered an error, please try again later")
 	case http.StatusBadGateway:
 		return errors.New("there was a problem with the server. Please try again later")
 	case http.StatusServiceUnavailable:
-		return errors.New("there are temporarily offline for maintenance. please try again later")
+		return errors.New("the service is temporarily unavailable, please try again later")
 	case http.StatusGatewayTimeout:
-		return errors.New("there are temporarily offline for maintenance. please try again later")
+		return errors.New("the service is temporarily unavailable, please try again later")
 	default:
 		return fmt.Errorf("unexpected status code: %d", statusCode)
 	}

--- a/backend/pkg/tools/tavily.go
+++ b/backend/pkg/tools/tavily.go
@@ -180,23 +180,23 @@ func (t *tavily) parseHTTPResponse(ctx context.Context, resp *http.Response) (st
 	case http.StatusBadRequest:
 		return "", fmt.Errorf("request is invalid")
 	case http.StatusUnauthorized:
-		return "", fmt.Errorf("API key is wrong")
+		return "", fmt.Errorf("API key is invalid")
 	case http.StatusForbidden:
 		return "", fmt.Errorf("the endpoint requested is hidden for administrators only")
 	case http.StatusNotFound:
 		return "", fmt.Errorf("the specified endpoint could not be found")
 	case http.StatusMethodNotAllowed:
-		return "", fmt.Errorf("there need to try to access an endpoint with an invalid method")
+		return "", fmt.Errorf("the endpoint does not allow this HTTP method")
 	case http.StatusTooManyRequests:
-		return "", fmt.Errorf("there are requesting too many results")
+		return "", fmt.Errorf("too many requests, please slow down")
 	case http.StatusInternalServerError:
-		return "", fmt.Errorf("there had a problem with our server. try again later")
+		return "", fmt.Errorf("the server encountered an error, please try again later")
 	case http.StatusBadGateway:
 		return "", fmt.Errorf("there was a problem with the server. Please try again later")
 	case http.StatusServiceUnavailable:
-		return "", fmt.Errorf("there are temporarily offline for maintenance. please try again later")
+		return "", fmt.Errorf("the service is temporarily unavailable, please try again later")
 	case http.StatusGatewayTimeout:
-		return "", fmt.Errorf("there are temporarily offline for maintenance. please try again later")
+		return "", fmt.Errorf("the service is temporarily unavailable, please try again later")
 	default:
 		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}


### PR DESCRIPTION
## Description of the Change

### Problem

\ and \ share identical HTTP error response handlers containing broken English strings:

| Status | Before | After |
|--------|--------|-------|
| 401 | \ | \ |
| 405 | \ | \ |
| 429 | \ | \ |
| 500 | \ | \ |
| 503/504 | \ | \ |

### Solution

Replace all 5 broken strings in both files with grammatically correct equivalents.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

### Areas Affected

- [x] AI Agents (Researcher / Developer / Executor)

### Testing and Verification

#### Test Steps
1. Trigger a 401 from Tavily/Perplexity with an invalid key — error message is now 2. All other error messages display correctly

### Security Considerations

No security implications. String-only change.

### Checklist

#### Code Quality
- [x] My code follows the project's coding standards
- [x] All new and existing tests pass
- [x] I have run \ and \ (for Go code)

#### Security
- [x] I have considered security implications
- [x] Changes maintain or improve the security model

#### Compatibility
- [x] Changes are backward compatible