### PR TITLE
fix: propagate container lookup error in GetTool

### DIFF
--- a/backend/cmd/ftester/worker/executor.go
+++ b/backend/cmd/ftester/worker/executor.go
@@ -93,10 +93,16 @@ func newToolExecutor(
 
 // GetTool returns the appropriate tool for a given function name
 func (te *toolExecutor) GetTool(ctx context.Context, funcName string) (tools.Tool, error) {
-	// Get primary container for terminal/file operations
+	// Get primary container for terminal/file operations (only when needed)
 	var containerID int64
 	var containerLID string
-	if cnt, err := te.db.GetFlowPrimaryContainer(ctx, te.flowID); err == nil {
+
+	requiresContainer := funcName == tools.TerminalToolName || funcName == tools.FileToolName
+	if requiresContainer {
+		cnt, err := te.db.GetFlowPrimaryContainer(ctx, te.flowID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get primary container for flow %d: %w", te.flowID, err)
+		}
 		containerID = cnt.ID
 		containerLID = cnt.LocalID.String
 	}


### PR DESCRIPTION
## Description

### Problem
`GetTool()` in `executor.go` silently ignores errors from `GetFlowPrimaryContainer` (lines 99-102). When the container lookup fails, `containerID` remains `0` and `containerLID` remains `""`. These invalid values are passed to `NewTerminalTool`, which later produces cryptic downstream errors like "container is not running" or Docker API errors about invalid container references.

The real root cause (missing/unreachable primary container) is hidden from the user.

### Solution
- Only call `GetFlowPrimaryContainer` when the tool actually requires a container (`TerminalToolName`, `FileToolName`)
- If the lookup fails, return the error immediately with flow ID context
- All other tools (15+) skip the unnecessary DB call entirely

Closes #145

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Areas Affected
- [x] Core Services (Backend API / Workers)
- [x] AI Agents (Tool Executor)

## Testing

### Configuration
- Local code review + CI validation

### Steps to Reproduce the Bug
1. Run ftester with a flow that has no primary container assigned
2. Attempt to use the Terminal or File tool
3. Observe cryptic errors like "container is not running" instead of "failed to get primary container for flow N"

### Expected Result After Fix
- Terminal/File tools: clear error "failed to get primary container for flow {id}: {cause}"
- All other tools: no change in behavior (container lookup was unnecessary for them)

## Security Considerations
- No security impact; this is an error handling improvement
- No new dependencies or attack surface

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] New and existing tests pass with my changes
- [x] My changes generate no new warnings
- [x] I have checked my code for potential security vulnerabilities
- [x] My changes are backward compatible