### PR TITLE
Fix browser tool to not discard content when screenshot fails

### DIFF
--- a/backend/pkg/tools/browser.go
+++ b/backend/pkg/tools/browser.go
@@ -158,8 +158,9 @@ func (b *browser) ContentMD(url string) (string, string, error) {
 	if errContent != nil {
 		return "", "", errContent
 	}
+
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		logrus.WithError(errScreenshot).Warnf("failed to capture screenshot for %s, continuing without it", url)
 	}
 
 	return content, screenshotName, nil
@@ -190,8 +191,9 @@ func (b *browser) ContentHTML(url string) (string, string, error) {
 	if errContent != nil {
 		return "", "", errContent
 	}
+
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		logrus.WithError(errScreenshot).Warnf("failed to capture screenshot for %s, continuing without it", url)
 	}
 
 	return content, screenshotName, nil
@@ -222,8 +224,9 @@ func (b *browser) Links(url string) (string, string, error) {
 	if errLinks != nil {
 		return "", "", errLinks
 	}
+
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		logrus.WithError(errScreenshot).Warnf("failed to capture screenshot for %s, continuing without it", url)
 	}
 
 	return links, screenshotName, nil


### PR DESCRIPTION
Fixes issue #149. The browser tool was discarding successfully-fetched page content when screenshot capture failed. Screenshot is a non-critical side-effect used only for logging, so failures should be logged as warnings without affecting the primary content fetch operation.

Changes:
- ContentMD: Log screenshot error as warning instead of returning error
- ContentHTML: Log screenshot error as warning instead of returning error  
- Links: Log screenshot error as warning instead of returning error

All three methods now return valid content with empty screenshot name when screenshot fails, rather than returning an error and discarding the content.