### PR TITLE
fix: treat screenshot failure as non-critical in browser tool

### DIFF
--- a/backend/pkg/tools/browser.go
+++ b/backend/pkg/tools/browser.go
@@ -159,7 +159,8 @@ func (b *browser) ContentMD(url string) (string, string, error) {
 		return "", "", errContent
 	}
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		log.Printf("Warning: screenshot failed for %s (content still available): %v", url, errScreenshot)
+		screenshotName = ""
 	}
 
 	return content, screenshotName, nil
@@ -191,7 +192,8 @@ func (b *browser) ContentHTML(url string) (string, string, error) {
 		return "", "", errContent
 	}
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		log.Printf("Warning: screenshot failed for %s (content still available): %v", url, errScreenshot)
+		screenshotName = ""
 	}
 
 	return content, screenshotName, nil
@@ -223,7 +225,8 @@ func (b *browser) Links(url string) (string, string, error) {
 		return "", "", errLinks
 	}
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		log.Printf("Warning: screenshot failed for %s (links still available): %v", url, errScreenshot)
+		screenshotName = ""
 	}
 
 	return links, screenshotName, nil


### PR DESCRIPTION
## Problem

In `backend/pkg/tools/browser.go`, the `ContentMD`, `ContentHTML`, and `Links` methods run two concurrent operations: fetching page content and capturing a screenshot. If the screenshot fails (scraper unavailable, timeout, image too small), the function returns an error **discarding successfully-fetched page content**.

The AI agent receives an error instead of the content it needs. Screenshot is a non-critical side-effect — `PutScreenshot` already ignores errors at the call-site.

Reported in #149.

## Solution

Log a warning on screenshot failure instead of returning an error. Content is preserved.

```go
if errScreenshot != nil {
    log.Printf("Warning: screenshot failed for %s (content still available): %v", url, errScreenshot)
    screenshotName = ""
}
```

## Changes

- `backend/pkg/tools/browser.go`: 3 methods changed — `ContentMD()`, `ContentHTML()`, `Links()` (+6/-3)

## Testing

- Content succeeds + screenshot fails → content returned ✅
- Both succeed → unchanged ✅
- Content fails → error returned ✅

Closes #149