### PR TITLE
fix(browser): treat screenshot failure as non-critical warning

### DIFF
--- a/backend/pkg/tools/browser.go
+++ b/backend/pkg/tools/browser.go
@@ -158,8 +158,11 @@ func (b *browser) ContentMD(url string) (string, string, error) {
 	if errContent != nil {
 		return "", "", errContent
 	}
+
+	// Screenshot is non-critical: log the failure but return valid content
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		logrus.WithError(errScreenshot).Warnf("failed to capture screenshot for %s, continuing without it", url)
+		screenshotName = ""
 	}
 
 	return content, screenshotName, nil
@@ -190,8 +193,11 @@ func (b *browser) ContentHTML(url string) (string, string, error) {
 	if errContent != nil {
 		return "", "", errContent
 	}
+
+	// Screenshot is non-critical: log the failure but return valid content
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		logrus.WithError(errScreenshot).Warnf("failed to capture screenshot for %s, continuing without it", url)
+		screenshotName = ""
 	}
 
 	return content, screenshotName, nil
@@ -222,8 +228,11 @@ func (b *browser) Links(url string) (string, string, error) {
 	if errLinks != nil {
 		return "", "", errLinks
 	}
+
+	// Screenshot is non-critical: log the failure but return valid content
 	if errScreenshot != nil {
-		return "", "", errScreenshot
+		logrus.WithError(errScreenshot).Warnf("failed to capture screenshot for %s, continuing without it", url)
+		screenshotName = ""
 	}
 
 	return links, screenshotName, nil


### PR DESCRIPTION
## Summary

Fixes #149

The browser tool's `ContentMD`, `ContentHTML`, and `Links` methods run content fetching and screenshot capture concurrently. Currently, if the screenshot fails for any reason, the **entire operation returns an error** — discarding successfully-fetched page content.

This PR makes screenshot failure non-critical: when content is successfully fetched but the screenshot fails, a warning is logged and the content is returned with an empty screenshot name.

## Problem

Screenshot failures can occur due to:
- Scraper service being temporarily unavailable or restarting
- Network timeout (65s hard timeout)
- Target page producing a screenshot smaller than `minImgContentSize` (2048 bytes)
- Disk write failure in `writeScreenshotToFile`

Since the caller (`wrapCommandResult`) already treats the screenshot as optional (`_, _ = b.scp.PutScreenshot(...)`), the screenshot result is already considered disposable at the call-site. Yet the producing function can abort the entire operation.

## Changes

In `ContentMD()`, `ContentHTML()`, and `Links()`:
- Screenshot errors are now logged as warnings via `logrus.WithError(...).Warnf()`
- `screenshotName` is set to empty string on failure
- Valid content is returned instead of being discarded

## Before / After

**Before:** Agent receives `browser tool 'markdown' handled with error: failed to fetch screenshot...` even though content was fetched successfully.

**After:** Agent receives the page content. A warning is logged for debugging.