### PR TITLE
fix: correct typo in terminal ReadFile output message

### DIFF
--- a/backend/pkg/tools/terminal.go
+++ b/backend/pkg/tools/terminal.go
@@ -297,7 +297,7 @@ func (t *terminal) ReadFile(ctx context.Context, flowID int64, path string) (str
 		if stats.Mode.IsDir() {
 			buffer.WriteString("--------------------------------------------------\n")
 			buffer.WriteString(
-				fmt.Sprintf("'%s' file content (with size %d bytes) keeps bellow:\n",
+				fmt.Sprintf("'%s' file content (with size %d bytes) shown below:\n",
 					tarHeader.Name, tarHeader.Size,
 				),
 			)


### PR DESCRIPTION
### Description of the Change

#### Problem

The `ReadFile()` method in `terminal.go` displays a header for each file when reading a directory:

```
'filename' file content (with size N bytes) keeps bellow:
```

This contains a typo: **"bellow"** means "to shout loudly" (as in a bull bellowing). The intended word is **"below"** (underneath). The phrase "keeps below" is also awkward -- "shown below" is clearer.

#### Solution

Changed `"keeps bellow"` to `"shown below"` on line 300 of `terminal.go`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Areas Affected

- [x] Core Services (Backend API / Workers)

### Testing and Verification

#### Test Configuration
```yaml
PentAGI Version: v1.2.0 (master @ e97bbe5)
Docker Version: N/A (single-line string change)
Host OS: Windows 11
LLM Provider: N/A
```

#### Test Steps
1. Verified the typo exists on current master (line 300)
2. Changed "keeps bellow" to "shown below"
3. Verified no other occurrences of "bellow" in the codebase

#### Test Results
- String-only change, no logic affected
- No test breakage (the output string is not asserted in any test)

### Security Considerations

No security impact. This is a cosmetic fix to a user-facing output string.

### Performance Impact

None.

### Documentation Updates

- [ ] README.md updates
- [ ] API documentation updates
- [ ] Configuration documentation updates
- [ ] GraphQL schema updates
- [ ] Other

No documentation changes required.

### Deployment Notes

Backward-compatible. No configuration changes needed.

### Checklist

#### Code Quality
- [x] My code follows the project's coding standards
- [x] I have added/updated necessary documentation
- [x] All new and existing tests pass
- [x] I have run `go fmt` and `go vet` (for Go code)

#### Security
- [x] I have considered security implications
- [x] Changes maintain or improve the security model
- [x] Sensitive information has been properly handled

#### Compatibility
- [x] Changes are backward compatible
- [x] Dependencies are properly updated

#### Documentation
- [x] Documentation is clear and complete
- [x] Comments are added for non-obvious code