### PR TITLE
test: add unit tests for Bool and Int64 custom JSON types

### DIFF
--- a/backend/pkg/tools/args_test.go
+++ b/backend/pkg/tools/args_test.go
@@ -37,6 +37,8 @@ func TestBoolUnmarshalJSON(t *testing.T) {
 		{name: "whitespace padded true", input: `" true "`, want: true},
 		{name: "whitespace padded false", input: `" false "`, want: false},
 		{name: "tab and newline around true", input: "\"\ttrue\n\"", want: true},
+		{name: "carriage return around true", input: "\"\rtrue\r\"", want: true},
+		{name: "null literal", input: `null`, wantErr: true},
 		{name: "invalid yes", input: `"yes"`, wantErr: true},
 		{name: "invalid 1", input: `"1"`, wantErr: true},
 		{name: "invalid 0", input: `"0"`, wantErr: true},
@@ -153,10 +155,15 @@ func TestInt64UnmarshalJSON(t *testing.T) {
 		{name: "quoted negative", input: `"-456"`, want: -456},
 		{name: "quoted zero", input: `"0"`, want: 0},
 		{name: "single-quoted positive", input: `"'789'"`, want: 789},
+		{name: "single-quoted negative", input: `"'-5'"`, want: -5},
 		{name: "whitespace padded", input: `" 100 "`, want: 100},
+		{name: "tab around value", input: "\"\t99\t\"", want: 99},
 		{name: "newline around value", input: "\"\n50\n\"", want: 50},
 		{name: "max int64", input: `"9223372036854775807"`, want: Int64(9223372036854775807)},
 		{name: "min int64", input: `"-9223372036854775808"`, want: Int64(-9223372036854775808)},
+		{name: "null literal", input: `null`, wantErr: true},
+		{name: "overflow int64", input: `"9223372036854775808"`, wantErr: true},
+		{name: "underflow int64", input: `"-9223372036854775809"`, wantErr: true},
 		{name: "invalid string", input: `"abc"`, wantErr: true},
 		{name: "invalid float", input: `"1.5"`, wantErr: true},
 		{name: "empty string", input: `""`, wantErr: true},
@@ -244,6 +251,7 @@ func TestInt64Int64Method(t *testing.T) {
 	}{
 		{name: "positive value", i: int64Ptr(42), want: 42},
 		{name: "negative value", i: int64Ptr(-7), want: -7},
+		{name: "zero value", i: int64Ptr(0), want: 0},
 		{name: "nil pointer", i: nil, want: 0},
 	}
 
@@ -268,6 +276,7 @@ func TestInt64PtrInt64(t *testing.T) {
 		want    int64
 	}{
 		{name: "positive value", i: int64Ptr(42), wantNil: false, want: 42},
+		{name: "negative value", i: int64Ptr(-7), wantNil: false, want: -7},
 		{name: "zero value", i: int64Ptr(0), wantNil: false, want: 0},
 		{name: "nil pointer", i: nil, wantNil: true},
 	}


### PR DESCRIPTION
## Description

Add comprehensive unit tests for the custom `Bool` and `Int64` types in `backend/pkg/tools/args.go`. These types are used throughout the tool argument system to handle LLM-produced JSON that may represent booleans and integers as quoted strings.

## Type of Change

- [x] New tests (no production code changes)

## Areas Affected

- `backend/pkg/tools/args_test.go` (new file)

## Testing

All tests are self-contained, table-driven, and use `t.Parallel()`. Test coverage includes:

**Bool type (6 test functions):**
- `TestBoolUnmarshalJSON` - bare values, quoted strings, case-insensitive parsing, single-quoted wrappers, whitespace/tab trimming, invalid inputs (yes, 1, 0, empty string, arbitrary words)
- `TestBoolMarshalJSON` - true/false values, nil pointer returns false
- `TestBoolBool` - accessor method with nil safety
- `TestBoolString` - string conversion with nil returns empty
- `TestBoolJSONRoundTrip` - marshal/unmarshal round-trip via struct embedding

**Int64 type (7 test functions):**
- `TestInt64UnmarshalJSON` - bare integers, quoted strings, single-quoted wrappers, whitespace trimming, min/max int64 boundary values, invalid inputs (float, string, empty, bool)
- `TestInt64MarshalJSON` - positive/negative/zero values, nil pointer returns 0
- `TestInt64Int` - int accessor with nil safety
- `TestInt64Int64Method` - int64 accessor with nil safety
- `TestInt64PtrInt64` - pointer conversion with nil returns nil
- `TestInt64String` - string conversion with nil returns empty
- `TestInt64JSONRoundTrip` - marshal/unmarshal round-trip via struct embedding

## Security Considerations

No security impact - test-only changes.

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have performed a self-review of my own code
- [x] New tests added for the changes
- [x] Tests follow project conventions (table-driven, t.Parallel(), same package)