### PR TITLE
test: add unit tests for executor helpers and terminal utilities

### DIFF
--- a/backend/pkg/tools/executor_test.go
+++ b/backend/pkg/tools/executor_test.go
@@ -1,0 +1,193 @@
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestGetMessage(t *testing.T) {
+	t.Parallel()
+
+	ce := &customExecutor{}
+
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{
+			name: "valid message field",
+			args: `{"message": "hello world", "other": "data"}`,
+			want: "hello world",
+		},
+		{
+			name: "empty message",
+			args: `{"message": ""}`,
+			want: "",
+		},
+		{
+			name: "missing message field",
+			args: `{"other": "data"}`,
+			want: "",
+		},
+		{
+			name: "invalid json",
+			args: `{invalid}`,
+			want: "",
+		},
+		{
+			name: "empty json object",
+			args: `{}`,
+			want: "",
+		},
+		{
+			name: "message with unicode",
+			args: `{"message": "testing: \u0041\u0042\u0043"}`,
+			want: "testing: ABC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ce.getMessage(json.RawMessage(tt.args))
+			if got != tt.want {
+				t.Errorf("getMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestArgsToMarkdown(t *testing.T) {
+	t.Parallel()
+
+	ce := &customExecutor{}
+
+	tests := []struct {
+		name    string
+		args    string
+		wantErr bool
+		check   func(t *testing.T, result string)
+	}{
+		{
+			name: "single field",
+			args: `{"query": "test search"}`,
+			check: func(t *testing.T, result string) {
+				if !strings.Contains(result, "* query: test search") {
+					t.Errorf("expected query bullet, got: %s", result)
+				}
+			},
+		},
+		{
+			name: "message field skipped",
+			args: `{"query": "test", "message": "should be skipped"}`,
+			check: func(t *testing.T, result string) {
+				if strings.Contains(result, "message") {
+					t.Error("message field should be skipped")
+				}
+				if !strings.Contains(result, "* query: test") {
+					t.Errorf("expected query bullet, got: %s", result)
+				}
+			},
+		},
+		{
+			name: "only message field",
+			args: `{"message": "only message"}`,
+			check: func(t *testing.T, result string) {
+				if result != "" {
+					t.Errorf("expected empty string when only message field, got: %q", result)
+				}
+			},
+		},
+		{
+			name:    "invalid json",
+			args:    `{invalid}`,
+			wantErr: true,
+		},
+		{
+			name: "empty json object",
+			args: `{}`,
+			check: func(t *testing.T, result string) {
+				if result != "" {
+					t.Errorf("expected empty result for empty args, got: %q", result)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ce.argsToMarkdown(json.RawMessage(tt.args))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("argsToMarkdown() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+func TestIsBarrierFunction(t *testing.T) {
+	t.Parallel()
+
+	ce := &customExecutor{
+		barriers: map[string]struct{}{
+			FinalyToolName:  {},
+			AskUserToolName: {},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		toolName string
+		want     bool
+	}{
+		{name: "done is barrier", toolName: FinalyToolName, want: true},
+		{name: "ask is barrier", toolName: AskUserToolName, want: true},
+		{name: "terminal is not barrier", toolName: TerminalToolName, want: false},
+		{name: "empty string is not barrier", toolName: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ce.IsBarrierFunction(tt.toolName); got != tt.want {
+				t.Errorf("IsBarrierFunction(%q) = %v, want %v", tt.toolName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetBarrierToolNames(t *testing.T) {
+	t.Parallel()
+
+	ce := &customExecutor{
+		barriers: map[string]struct{}{
+			FinalyToolName:  {},
+			AskUserToolName: {},
+		},
+	}
+
+	names := ce.GetBarrierToolNames()
+	if len(names) != 2 {
+		t.Fatalf("GetBarrierToolNames() returned %d names, want 2", len(names))
+	}
+
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	if !nameSet[FinalyToolName] {
+		t.Errorf("GetBarrierToolNames() missing %q", FinalyToolName)
+	}
+	if !nameSet[AskUserToolName] {
+		t.Errorf("GetBarrierToolNames() missing %q", AskUserToolName)
+	}
+}

--- a/backend/pkg/tools/terminal_test.go
+++ b/backend/pkg/tools/terminal_test.go
@@ -1,0 +1,102 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestPrimaryTerminalName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		flowID int64
+		want   string
+	}{
+		{1, "pentagi-terminal-1"},
+		{0, "pentagi-terminal-0"},
+		{12345, "pentagi-terminal-12345"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("flowID=%d", tt.flowID), func(t *testing.T) {
+			t.Parallel()
+
+			if got := PrimaryTerminalName(tt.flowID); got != tt.want {
+				t.Errorf("PrimaryTerminalName(%d) = %q, want %q", tt.flowID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTerminalInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cwd  string
+		text string
+	}{
+		{name: "basic command", cwd: "/home/user", text: "ls -la"},
+		{name: "empty cwd", cwd: "", text: "pwd"},
+		{name: "complex command", cwd: "/tmp", text: "find . -name '*.go'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := FormatTerminalInput(tt.cwd, tt.text)
+			if !strings.Contains(result, tt.cwd) {
+				t.Errorf("result should contain cwd %q", tt.cwd)
+			}
+			if !strings.Contains(result, tt.text) {
+				t.Errorf("result should contain text %q", tt.text)
+			}
+			if !strings.HasSuffix(result, "\r\n") {
+				t.Error("result should end with CRLF")
+			}
+			// Should contain ANSI yellow escape code
+			if !strings.Contains(result, "\033[33m") {
+				t.Error("result should contain yellow ANSI code")
+			}
+			if !strings.Contains(result, "\033[0m") {
+				t.Error("result should contain reset ANSI code")
+			}
+		})
+	}
+}
+
+func TestFormatTerminalSystemOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+	}{
+		{name: "simple output", text: "file written successfully"},
+		{name: "empty output", text: ""},
+		{name: "multiline output", text: "line 1\nline 2\nline 3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := FormatTerminalSystemOutput(tt.text)
+			if !strings.Contains(result, tt.text) {
+				t.Errorf("result should contain text %q", tt.text)
+			}
+			if !strings.HasSuffix(result, "\r\n") {
+				t.Error("result should end with CRLF")
+			}
+			// Should contain ANSI blue escape code
+			if !strings.Contains(result, "\033[34m") {
+				t.Error("result should contain blue ANSI code")
+			}
+			if !strings.Contains(result, "\033[0m") {
+				t.Error("result should contain reset ANSI code")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add unit tests for helper functions in two core modules:
- `backend/pkg/tools/executor.go` - JSON argument processing and barrier function management
- `backend/pkg/tools/terminal.go` - Terminal name generation and ANSI-formatted output

## Type of Change

- [x] New tests (no production code changes)

## Areas Affected

- `backend/pkg/tools/executor_test.go` (new file)
- `backend/pkg/tools/terminal_test.go` (new file)

## Testing

All tests are self-contained, table-driven, and use `t.Parallel()`.

**executor_test.go (4 test functions):**
- `TestGetMessage` - extracts "message" field from JSON args; covers valid message, empty message, missing field, invalid JSON, empty object, unicode content
- `TestArgsToMarkdown` - converts JSON args to markdown bullet list; verifies "message" key is skipped, handles single/multiple fields, invalid JSON errors, empty objects
- `TestIsBarrierFunction` - checks barrier map membership for known barriers (done, ask_user) and non-barriers
- `TestGetBarrierToolNames` - returns all registered barrier tool names, verifies count and contents

**terminal_test.go (3 test functions):**
- `TestPrimaryTerminalName` - generates "pentagi-terminal-{flowID}" format for various flow IDs
- `TestFormatTerminalInput` - ANSI yellow-colored terminal input with cwd prefix, verifies color codes and line endings
- `TestFormatTerminalSystemOutput` - ANSI blue-colored system output, verifies color codes and content wrapping

## Security Considerations

No security impact - test-only changes.

## Checklist

- [x] My code follows the existing code style of this project
- [x] I have performed a self-review of my own code
- [x] New tests added for the changes
- [x] Tests follow project conventions (table-driven, t.Parallel(), same package)