### PR TITLE
test: add unit tests for DeepSeek, GLM, Kimi, and Qwen providers

### DIFF
--- a/backend/pkg/providers/deepseek/deepseek_test.go
+++ b/backend/pkg/providers/deepseek/deepseek_test.go
@@ -1,0 +1,202 @@
+package deepseek
+
+import (
+	"testing"
+
+	"pentagi/pkg/config"
+	"pentagi/pkg/providers/pconfig"
+	"pentagi/pkg/providers/provider"
+)
+
+func TestConfigLoading(t *testing.T) {
+	cfg := &config.Config{
+		DeepSeekAPIKey:    "test-key",
+		DeepSeekServerURL: "https://api.deepseek.com",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	rawConfig := prov.GetRawConfig()
+	if len(rawConfig) == 0 {
+		t.Fatal("Raw config should not be empty")
+	}
+
+	providerConfig = prov.GetProviderConfig()
+	if providerConfig == nil {
+		t.Fatal("Provider config should not be nil")
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		model := prov.Model(agentType)
+		if model == "" {
+			t.Errorf("Agent type %v should have a model assigned", agentType)
+		}
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		priceInfo := prov.GetPriceInfo(agentType)
+		if priceInfo == nil {
+			t.Errorf("Agent type %v should have price information", agentType)
+		} else {
+			if priceInfo.Input <= 0 || priceInfo.Output <= 0 {
+				t.Errorf("Agent type %v should have positive input (%f) and output (%f) prices",
+					agentType, priceInfo.Input, priceInfo.Output)
+			}
+		}
+	}
+}
+
+func TestProviderType(t *testing.T) {
+	cfg := &config.Config{
+		DeepSeekAPIKey:    "test-key",
+		DeepSeekServerURL: "https://api.deepseek.com",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	if prov.Type() != provider.ProviderDeepSeek {
+		t.Errorf("Expected provider type %v, got %v", provider.ProviderDeepSeek, prov.Type())
+	}
+}
+
+func TestModelsLoading(t *testing.T) {
+	models, err := DefaultModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	if len(models) == 0 {
+		t.Fatal("Models list should not be empty")
+	}
+
+	for _, model := range models {
+		if model.Name == "" {
+			t.Error("Model name should not be empty")
+		}
+
+		if model.Price == nil {
+			t.Errorf("Model %s should have price information", model.Name)
+			continue
+		}
+
+		if model.Price.Input <= 0 {
+			t.Errorf("Model %s should have positive input price", model.Name)
+		}
+
+		if model.Price.Output <= 0 {
+			t.Errorf("Model %s should have positive output price", model.Name)
+		}
+	}
+}
+
+func TestModelWithPrefix(t *testing.T) {
+	cfg := &config.Config{
+		DeepSeekAPIKey:    "test-key",
+		DeepSeekServerURL: "https://api.deepseek.com",
+		DeepSeekProvider:   "deepseek",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		expected := "deepseek/" + model
+		if modelWithPrefix != expected {
+			t.Errorf("Agent type %v: expected prefixed model %q, got %q", agentType, expected, modelWithPrefix)
+		}
+	}
+}
+
+func TestModelWithoutPrefix(t *testing.T) {
+	cfg := &config.Config{
+		DeepSeekAPIKey:    "test-key",
+		DeepSeekServerURL: "https://api.deepseek.com",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		if modelWithPrefix != model {
+			t.Errorf("Agent type %v: without prefix, ModelWithPrefix (%q) should equal Model (%q)",
+				agentType, modelWithPrefix, model)
+		}
+	}
+}
+
+func TestMissingAPIKey(t *testing.T) {
+	cfg := &config.Config{
+		DeepSeekServerURL: "https://api.deepseek.com",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	_, err = New(cfg, providerConfig)
+	if err == nil {
+		t.Fatal("Expected error when API key is missing")
+	}
+}
+
+func TestGetUsage(t *testing.T) {
+	cfg := &config.Config{
+		DeepSeekAPIKey:    "test-key",
+		DeepSeekServerURL: "https://api.deepseek.com",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	usage := prov.GetUsage(map[string]any{
+		"PromptTokens":     100,
+		"CompletionTokens": 50,
+	})
+	if usage.Input != 100 || usage.Output != 50 {
+		t.Errorf("Expected usage input=100 output=50, got input=%d output=%d", usage.Input, usage.Output)
+	}
+}

--- a/backend/pkg/providers/glm/glm_test.go
+++ b/backend/pkg/providers/glm/glm_test.go
@@ -1,0 +1,202 @@
+package glm
+
+import (
+	"testing"
+
+	"pentagi/pkg/config"
+	"pentagi/pkg/providers/pconfig"
+	"pentagi/pkg/providers/provider"
+)
+
+func TestConfigLoading(t *testing.T) {
+	cfg := &config.Config{
+		GLMAPIKey:    "test-key",
+		GLMServerURL: "https://api.z.ai/api/paas/v4",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	rawConfig := prov.GetRawConfig()
+	if len(rawConfig) == 0 {
+		t.Fatal("Raw config should not be empty")
+	}
+
+	providerConfig = prov.GetProviderConfig()
+	if providerConfig == nil {
+		t.Fatal("Provider config should not be nil")
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		model := prov.Model(agentType)
+		if model == "" {
+			t.Errorf("Agent type %v should have a model assigned", agentType)
+		}
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		priceInfo := prov.GetPriceInfo(agentType)
+		if priceInfo == nil {
+			t.Errorf("Agent type %v should have price information", agentType)
+		} else {
+			if priceInfo.Input < 0 || priceInfo.Output < 0 {
+				t.Errorf("Agent type %v should have non-negative input (%f) and output (%f) prices",
+					agentType, priceInfo.Input, priceInfo.Output)
+			}
+		}
+	}
+}
+
+func TestProviderType(t *testing.T) {
+	cfg := &config.Config{
+		GLMAPIKey:    "test-key",
+		GLMServerURL: "https://api.z.ai/api/paas/v4",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	if prov.Type() != provider.ProviderGLM {
+		t.Errorf("Expected provider type %v, got %v", provider.ProviderGLM, prov.Type())
+	}
+}
+
+func TestModelsLoading(t *testing.T) {
+	models, err := DefaultModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	if len(models) == 0 {
+		t.Fatal("Models list should not be empty")
+	}
+
+	for _, model := range models {
+		if model.Name == "" {
+			t.Error("Model name should not be empty")
+		}
+
+		if model.Price == nil {
+			t.Errorf("Model %s should have price information", model.Name)
+			continue
+		}
+
+		if model.Price.Input < 0 {
+			t.Errorf("Model %s should have non-negative input price", model.Name)
+		}
+
+		if model.Price.Output < 0 {
+			t.Errorf("Model %s should have non-negative output price", model.Name)
+		}
+	}
+}
+
+func TestModelWithPrefix(t *testing.T) {
+	cfg := &config.Config{
+		GLMAPIKey:    "test-key",
+		GLMServerURL: "https://api.z.ai/api/paas/v4",
+		GLMProvider:   "zhipu",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		expected := "zhipu/" + model
+		if modelWithPrefix != expected {
+			t.Errorf("Agent type %v: expected prefixed model %q, got %q", agentType, expected, modelWithPrefix)
+		}
+	}
+}
+
+func TestModelWithoutPrefix(t *testing.T) {
+	cfg := &config.Config{
+		GLMAPIKey:    "test-key",
+		GLMServerURL: "https://api.z.ai/api/paas/v4",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		if modelWithPrefix != model {
+			t.Errorf("Agent type %v: without prefix, ModelWithPrefix (%q) should equal Model (%q)",
+				agentType, modelWithPrefix, model)
+		}
+	}
+}
+
+func TestMissingAPIKey(t *testing.T) {
+	cfg := &config.Config{
+		GLMServerURL: "https://api.z.ai/api/paas/v4",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	_, err = New(cfg, providerConfig)
+	if err == nil {
+		t.Fatal("Expected error when API key is missing")
+	}
+}
+
+func TestGetUsage(t *testing.T) {
+	cfg := &config.Config{
+		GLMAPIKey:    "test-key",
+		GLMServerURL: "https://api.z.ai/api/paas/v4",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	usage := prov.GetUsage(map[string]any{
+		"PromptTokens":     100,
+		"CompletionTokens": 50,
+	})
+	if usage.Input != 100 || usage.Output != 50 {
+		t.Errorf("Expected usage input=100 output=50, got input=%d output=%d", usage.Input, usage.Output)
+	}
+}

--- a/backend/pkg/providers/kimi/kimi_test.go
+++ b/backend/pkg/providers/kimi/kimi_test.go
@@ -1,0 +1,202 @@
+package kimi
+
+import (
+	"testing"
+
+	"pentagi/pkg/config"
+	"pentagi/pkg/providers/pconfig"
+	"pentagi/pkg/providers/provider"
+)
+
+func TestConfigLoading(t *testing.T) {
+	cfg := &config.Config{
+		KimiAPIKey:    "test-key",
+		KimiServerURL: "https://api.moonshot.ai/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	rawConfig := prov.GetRawConfig()
+	if len(rawConfig) == 0 {
+		t.Fatal("Raw config should not be empty")
+	}
+
+	providerConfig = prov.GetProviderConfig()
+	if providerConfig == nil {
+		t.Fatal("Provider config should not be nil")
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		model := prov.Model(agentType)
+		if model == "" {
+			t.Errorf("Agent type %v should have a model assigned", agentType)
+		}
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		priceInfo := prov.GetPriceInfo(agentType)
+		if priceInfo == nil {
+			t.Errorf("Agent type %v should have price information", agentType)
+		} else {
+			if priceInfo.Input <= 0 || priceInfo.Output <= 0 {
+				t.Errorf("Agent type %v should have positive input (%f) and output (%f) prices",
+					agentType, priceInfo.Input, priceInfo.Output)
+			}
+		}
+	}
+}
+
+func TestProviderType(t *testing.T) {
+	cfg := &config.Config{
+		KimiAPIKey:    "test-key",
+		KimiServerURL: "https://api.moonshot.ai/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	if prov.Type() != provider.ProviderKimi {
+		t.Errorf("Expected provider type %v, got %v", provider.ProviderKimi, prov.Type())
+	}
+}
+
+func TestModelsLoading(t *testing.T) {
+	models, err := DefaultModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	if len(models) == 0 {
+		t.Fatal("Models list should not be empty")
+	}
+
+	for _, model := range models {
+		if model.Name == "" {
+			t.Error("Model name should not be empty")
+		}
+
+		if model.Price == nil {
+			t.Errorf("Model %s should have price information", model.Name)
+			continue
+		}
+
+		if model.Price.Input <= 0 {
+			t.Errorf("Model %s should have positive input price", model.Name)
+		}
+
+		if model.Price.Output <= 0 {
+			t.Errorf("Model %s should have positive output price", model.Name)
+		}
+	}
+}
+
+func TestModelWithPrefix(t *testing.T) {
+	cfg := &config.Config{
+		KimiAPIKey:    "test-key",
+		KimiServerURL: "https://api.moonshot.ai/v1",
+		KimiProvider:   "moonshot",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		expected := "moonshot/" + model
+		if modelWithPrefix != expected {
+			t.Errorf("Agent type %v: expected prefixed model %q, got %q", agentType, expected, modelWithPrefix)
+		}
+	}
+}
+
+func TestModelWithoutPrefix(t *testing.T) {
+	cfg := &config.Config{
+		KimiAPIKey:    "test-key",
+		KimiServerURL: "https://api.moonshot.ai/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		if modelWithPrefix != model {
+			t.Errorf("Agent type %v: without prefix, ModelWithPrefix (%q) should equal Model (%q)",
+				agentType, modelWithPrefix, model)
+		}
+	}
+}
+
+func TestMissingAPIKey(t *testing.T) {
+	cfg := &config.Config{
+		KimiServerURL: "https://api.moonshot.ai/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	_, err = New(cfg, providerConfig)
+	if err == nil {
+		t.Fatal("Expected error when API key is missing")
+	}
+}
+
+func TestGetUsage(t *testing.T) {
+	cfg := &config.Config{
+		KimiAPIKey:    "test-key",
+		KimiServerURL: "https://api.moonshot.ai/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	usage := prov.GetUsage(map[string]any{
+		"PromptTokens":     100,
+		"CompletionTokens": 50,
+	})
+	if usage.Input != 100 || usage.Output != 50 {
+		t.Errorf("Expected usage input=100 output=50, got input=%d output=%d", usage.Input, usage.Output)
+	}
+}

--- a/backend/pkg/providers/qwen/qwen_test.go
+++ b/backend/pkg/providers/qwen/qwen_test.go
@@ -1,0 +1,202 @@
+package qwen
+
+import (
+	"testing"
+
+	"pentagi/pkg/config"
+	"pentagi/pkg/providers/pconfig"
+	"pentagi/pkg/providers/provider"
+)
+
+func TestConfigLoading(t *testing.T) {
+	cfg := &config.Config{
+		QwenAPIKey:    "test-key",
+		QwenServerURL: "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	rawConfig := prov.GetRawConfig()
+	if len(rawConfig) == 0 {
+		t.Fatal("Raw config should not be empty")
+	}
+
+	providerConfig = prov.GetProviderConfig()
+	if providerConfig == nil {
+		t.Fatal("Provider config should not be nil")
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		model := prov.Model(agentType)
+		if model == "" {
+			t.Errorf("Agent type %v should have a model assigned", agentType)
+		}
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		priceInfo := prov.GetPriceInfo(agentType)
+		if priceInfo == nil {
+			t.Errorf("Agent type %v should have price information", agentType)
+		} else {
+			if priceInfo.Input <= 0 || priceInfo.Output <= 0 {
+				t.Errorf("Agent type %v should have positive input (%f) and output (%f) prices",
+					agentType, priceInfo.Input, priceInfo.Output)
+			}
+		}
+	}
+}
+
+func TestProviderType(t *testing.T) {
+	cfg := &config.Config{
+		QwenAPIKey:    "test-key",
+		QwenServerURL: "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	if prov.Type() != provider.ProviderQwen {
+		t.Errorf("Expected provider type %v, got %v", provider.ProviderQwen, prov.Type())
+	}
+}
+
+func TestModelsLoading(t *testing.T) {
+	models, err := DefaultModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	if len(models) == 0 {
+		t.Fatal("Models list should not be empty")
+	}
+
+	for _, model := range models {
+		if model.Name == "" {
+			t.Error("Model name should not be empty")
+		}
+
+		if model.Price == nil {
+			t.Errorf("Model %s should have price information", model.Name)
+			continue
+		}
+
+		if model.Price.Input <= 0 {
+			t.Errorf("Model %s should have positive input price", model.Name)
+		}
+
+		if model.Price.Output <= 0 {
+			t.Errorf("Model %s should have positive output price", model.Name)
+		}
+	}
+}
+
+func TestModelWithPrefix(t *testing.T) {
+	cfg := &config.Config{
+		QwenAPIKey:    "test-key",
+		QwenServerURL: "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+		QwenProvider:   "tongyi",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		expected := "tongyi/" + model
+		if modelWithPrefix != expected {
+			t.Errorf("Agent type %v: expected prefixed model %q, got %q", agentType, expected, modelWithPrefix)
+		}
+	}
+}
+
+func TestModelWithoutPrefix(t *testing.T) {
+	cfg := &config.Config{
+		QwenAPIKey:    "test-key",
+		QwenServerURL: "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		if modelWithPrefix != model {
+			t.Errorf("Agent type %v: without prefix, ModelWithPrefix (%q) should equal Model (%q)",
+				agentType, modelWithPrefix, model)
+		}
+	}
+}
+
+func TestMissingAPIKey(t *testing.T) {
+	cfg := &config.Config{
+		QwenServerURL: "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	_, err = New(cfg, providerConfig)
+	if err == nil {
+		t.Fatal("Expected error when API key is missing")
+	}
+}
+
+func TestGetUsage(t *testing.T) {
+	cfg := &config.Config{
+		QwenAPIKey:    "test-key",
+		QwenServerURL: "https://dashscope-us.aliyuncs.com/compatible-mode/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	usage := prov.GetUsage(map[string]any{
+		"PromptTokens":     100,
+		"CompletionTokens": 50,
+	})
+	if usage.Input != 100 || usage.Output != 50 {
+		t.Errorf("Expected usage input=100 output=50, got input=%d output=%d", usage.Input, usage.Output)
+	}
+}


### PR DESCRIPTION
### Description of the Change

#### Problem

The four Chinese LLM providers (DeepSeek, GLM/Zhipu AI, Kimi/Moonshot AI, Qwen/Tongyi Qianwen) expanded in PR #185 had zero test coverage. Other providers like Anthropic, Bedrock, Gemini, and OpenAI all have comprehensive test suites.

#### Solution

Add unit tests for all four providers following the established test patterns (consistent with `anthropic_test.go`, `openai_test.go`, etc.):

- **TestConfigLoading**: Validates config creation, raw config, provider config, model assignment, and price information for all agent types
- **TestProviderType**: Verifies correct provider type constant
- **TestModelsLoading**: Validates embedded models.yml parsing, model names, and pricing
- **TestModelWithPrefix**: Tests LiteLLM proxy prefix behavior (`prefix/model-name`)
- **TestModelWithoutPrefix**: Verifies no-op when prefix is empty
- **TestMissingAPIKey**: Validates error on missing API key
- **TestGetUsage**: Tests token usage extraction

GLM tests use `< 0` (non-negative) price assertions instead of `<= 0` (positive) to accommodate free-tier models (`glm-4.7-flash`, `glm-4.5-flash`) with zero pricing.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

### Areas Affected

- [x] Core Services (Backend API)

### Testing and Verification

#### Test Configuration
- PentAGI Version: master (post-PR #185)
- Go Version: 1.24

#### Test Results
All 28 tests pass (7 per provider x 4 providers):

```
ok    pentagi/pkg/providers/deepseek  0.675s
ok    pentagi/pkg/providers/glm       2.576s
ok    pentagi/pkg/providers/kimi      0.677s
ok    pentagi/pkg/providers/qwen      0.711s
```

### Checklist

- [x] My code follows the project's coding standards
- [x] All new and existing tests pass
- [x] I have run `go fmt` and `go vet`
- [x] Security implications considered
- [x] Changes are backward compatible