### PR TITLE
test: add unit tests for pkg/version package

### DIFF
--- a/backend/pkg/version/version_test.go
+++ b/backend/pkg/version/version_test.go
@@ -1,0 +1,73 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBinaryVersion_Default(t *testing.T) {
+	PackageVer = ""
+	PackageRev = ""
+
+	result := GetBinaryVersion()
+	assert.Equal(t, "develop", result)
+}
+
+func TestGetBinaryVersion_WithVersion(t *testing.T) {
+	PackageVer = "1.2.0"
+	PackageRev = ""
+	defer func() { PackageVer = "" }()
+
+	result := GetBinaryVersion()
+	assert.Equal(t, "1.2.0", result)
+}
+
+func TestGetBinaryVersion_WithVersionAndRevision(t *testing.T) {
+	PackageVer = "1.2.0"
+	PackageRev = "abc1234"
+	defer func() {
+		PackageVer = ""
+		PackageRev = ""
+	}()
+
+	result := GetBinaryVersion()
+	assert.Equal(t, "1.2.0-abc1234", result)
+}
+
+func TestGetBinaryVersion_WithRevisionOnly(t *testing.T) {
+	PackageVer = ""
+	PackageRev = "abc1234"
+	defer func() { PackageRev = "" }()
+
+	result := GetBinaryVersion()
+	assert.Equal(t, "develop-abc1234", result)
+}
+
+func TestIsDevelopMode_True(t *testing.T) {
+	PackageVer = ""
+
+	assert.True(t, IsDevelopMode())
+}
+
+func TestIsDevelopMode_False(t *testing.T) {
+	PackageVer = "1.0.0"
+	defer func() { PackageVer = "" }()
+
+	assert.False(t, IsDevelopMode())
+}
+
+func TestGetBinaryName_Default(t *testing.T) {
+	PackageName = ""
+
+	result := GetBinaryName()
+	assert.Equal(t, "pentagi", result)
+}
+
+func TestGetBinaryName_Custom(t *testing.T) {
+	PackageName = "myservice"
+	defer func() { PackageName = "" }()
+
+	result := GetBinaryName()
+	assert.Equal(t, "myservice", result)
+}


### PR DESCRIPTION
## Description of Change

**Problem:** The `pkg/version` package has no unit test coverage. The package provides binary version, name, and development mode detection used throughout the application.

**Solution:** Add comprehensive unit tests for all three exported functions (`GetBinaryVersion`, `IsDevelopMode`, `GetBinaryName`) covering all code paths including default values, custom values, and combined version-revision formatting.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security update
- [x] Test update
- [ ] Documentation update
- [ ] Configuration change

## Areas Affected

- [x] Core Services (Frontend UI / Backend API)
- [ ] AI Agents (Researcher / Developer / Executor)
- [ ] Security Tools Integration
- [ ] Memory System (Vector Store / Knowledge Base)
- [ ] Monitoring Stack (Grafana / OpenTelemetry)
- [ ] Analytics & Reporting
- [ ] External Integrations (LLM Providers / Search Engines / Security APIs)
- [ ] Documentation
- [ ] Infrastructure / DevOps

## Testing and Verification

### Test Configuration
- PentAGI Version: v1.2.0 (master)
- Go Version: 1.24.1
- Host OS: Windows 11

### Test Steps
1. Run `go test ./pkg/version/... -v`

### Test Results
```
=== RUN   TestGetBinaryVersion_Default
--- PASS: TestGetBinaryVersion_Default (0.00s)
=== RUN   TestGetBinaryVersion_WithVersion
--- PASS: TestGetBinaryVersion_WithVersion (0.00s)
=== RUN   TestGetBinaryVersion_WithVersionAndRevision
--- PASS: TestGetBinaryVersion_WithVersionAndRevision (0.00s)
=== RUN   TestGetBinaryVersion_WithRevisionOnly
--- PASS: TestGetBinaryVersion_WithRevisionOnly (0.00s)
=== RUN   TestIsDevelopMode_True
--- PASS: TestIsDevelopMode_True (0.00s)
=== RUN   TestIsDevelopMode_False
--- PASS: TestIsDevelopMode_False (0.00s)
=== RUN   TestGetBinaryName_Default
--- PASS: TestGetBinaryName_Default (0.00s)
=== RUN   TestGetBinaryName_Custom
--- PASS: TestGetBinaryName_Custom (0.00s)
PASS
ok  	pentagi/pkg/version	4.393s
```

## Checklist

- [x] Code follows project coding standards
- [x] Tests added for changes
- [x] All tests pass
- [x] `go fmt` and `go vet` run
- [x] Changes are backward compatible