### PR TITLE
test: add unit tests for pkg/config package

### DIFF
--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -263,10 +263,62 @@ func TestGetSecretPatterns_AllFields(t *testing.T) {
 	t.Logf("successfully compiled %d total regexes", len(regexes))
 }
 
+// clearConfigEnv clears all environment variables referenced by Config struct tags
+// so that tests are hermetic and not affected by ambient environment.
+func clearConfigEnv(t *testing.T) {
+	t.Helper()
+
+	envVars := []string{
+		"DATABASE_URL", "DEBUG", "DATA_DIR", "ASK_USER", "INSTALLATION_ID", "LICENSE_KEY",
+		"DOCKER_INSIDE", "DOCKER_NET_ADMIN", "DOCKER_SOCKET", "DOCKER_NETWORK",
+		"DOCKER_PUBLIC_IP", "DOCKER_WORK_DIR", "DOCKER_DEFAULT_IMAGE", "DOCKER_DEFAULT_IMAGE_FOR_PENTEST",
+		"SERVER_PORT", "SERVER_HOST", "SERVER_USE_SSL", "SERVER_SSL_KEY", "SERVER_SSL_CRT",
+		"STATIC_URL", "STATIC_DIR", "CORS_ORIGINS", "COOKIE_SIGNING_SALT",
+		"SCRAPER_PUBLIC_URL", "SCRAPER_PRIVATE_URL",
+		"OPEN_AI_KEY", "OPEN_AI_SERVER_URL",
+		"ANTHROPIC_API_KEY", "ANTHROPIC_SERVER_URL",
+		"EMBEDDING_URL", "EMBEDDING_KEY", "EMBEDDING_MODEL",
+		"EMBEDDING_STRIP_NEW_LINES", "EMBEDDING_BATCH_SIZE", "EMBEDDING_PROVIDER",
+		"SUMMARIZER_PRESERVE_LAST", "SUMMARIZER_USE_QA", "SUMMARIZER_SUM_MSG_HUMAN_IN_QA",
+		"SUMMARIZER_LAST_SEC_BYTES", "SUMMARIZER_MAX_BP_BYTES",
+		"SUMMARIZER_MAX_QA_SECTIONS", "SUMMARIZER_MAX_QA_BYTES", "SUMMARIZER_KEEP_QA_SECTIONS",
+		"LLM_SERVER_URL", "LLM_SERVER_KEY", "LLM_SERVER_MODEL", "LLM_SERVER_PROVIDER",
+		"LLM_SERVER_CONFIG_PATH", "LLM_SERVER_LEGACY_REASONING", "LLM_SERVER_PRESERVE_REASONING",
+		"OLLAMA_SERVER_URL", "OLLAMA_SERVER_API_KEY", "OLLAMA_SERVER_MODEL",
+		"OLLAMA_SERVER_CONFIG_PATH", "OLLAMA_SERVER_PULL_MODELS_TIMEOUT",
+		"OLLAMA_SERVER_PULL_MODELS_ENABLED", "OLLAMA_SERVER_LOAD_MODELS_ENABLED",
+		"GEMINI_API_KEY", "GEMINI_SERVER_URL",
+		"BEDROCK_REGION", "BEDROCK_DEFAULT_AUTH", "BEDROCK_BEARER_TOKEN",
+		"BEDROCK_ACCESS_KEY_ID", "BEDROCK_SECRET_ACCESS_KEY", "BEDROCK_SESSION_TOKEN", "BEDROCK_SERVER_URL",
+		"DEEPSEEK_API_KEY", "DEEPSEEK_SERVER_URL", "DEEPSEEK_PROVIDER",
+		"GLM_API_KEY", "GLM_SERVER_URL", "GLM_PROVIDER",
+		"KIMI_API_KEY", "KIMI_SERVER_URL", "KIMI_PROVIDER",
+		"QWEN_API_KEY", "QWEN_SERVER_URL", "QWEN_PROVIDER",
+		"DUCKDUCKGO_ENABLED", "DUCKDUCKGO_REGION", "DUCKDUCKGO_SAFESEARCH", "DUCKDUCKGO_TIME_RANGE",
+		"SPLOITUS_ENABLED",
+		"GOOGLE_API_KEY", "GOOGLE_CX_KEY", "GOOGLE_LR_KEY",
+		"OAUTH_GOOGLE_CLIENT_ID", "OAUTH_GOOGLE_CLIENT_SECRET",
+		"OAUTH_GITHUB_CLIENT_ID", "OAUTH_GITHUB_CLIENT_SECRET",
+		"PUBLIC_URL", "TRAVERSAAL_API_KEY", "TAVILY_API_KEY",
+		"PERPLEXITY_API_KEY", "PERPLEXITY_MODEL", "PERPLEXITY_CONTEXT_SIZE",
+		"SEARXNG_URL", "SEARXNG_CATEGORIES", "SEARXNG_LANGUAGE",
+		"SEARXNG_SAFESEARCH", "SEARXNG_TIME_RANGE", "SEARXNG_TIMEOUT",
+		"ASSISTANT_USE_AGENTS", "ASSISTANT_SUMMARIZER_PRESERVE_LAST",
+		"ASSISTANT_SUMMARIZER_LAST_SEC_BYTES", "ASSISTANT_SUMMARIZER_MAX_BP_BYTES",
+		"ASSISTANT_SUMMARIZER_MAX_QA_SECTIONS", "ASSISTANT_SUMMARIZER_MAX_QA_BYTES",
+		"ASSISTANT_SUMMARIZER_KEEP_QA_SECTIONS",
+		"PROXY_URL", "EXTERNAL_SSL_CA_PATH", "EXTERNAL_SSL_INSECURE",
+		"OTEL_HOST", "LANGFUSE_BASE_URL", "LANGFUSE_PROJECT_ID", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY",
+		"GRAPHITI_ENABLED", "GRAPHITI_TIMEOUT", "GRAPHITI_URL",
+	}
+	for _, v := range envVars {
+		t.Setenv(v, "")
+	}
+}
+
 func TestNewConfig_Defaults(t *testing.T) {
-	// Unset env vars that would override defaults
-	t.Setenv("DATABASE_URL", "")
-	t.Setenv("LICENSE_KEY", "")
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -286,10 +338,12 @@ func TestNewConfig_Defaults(t *testing.T) {
 }
 
 func TestNewConfig_EnvOverride(t *testing.T) {
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
+
 	t.Setenv("SERVER_PORT", "9090")
 	t.Setenv("SERVER_HOST", "127.0.0.1")
 	t.Setenv("DEBUG", "true")
-	t.Setenv("LICENSE_KEY", "")
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -301,7 +355,8 @@ func TestNewConfig_EnvOverride(t *testing.T) {
 }
 
 func TestNewConfig_ProviderDefaults(t *testing.T) {
-	t.Setenv("LICENSE_KEY", "")
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -317,8 +372,10 @@ func TestNewConfig_ProviderDefaults(t *testing.T) {
 }
 
 func TestNewConfig_StaticURL(t *testing.T) {
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
+
 	t.Setenv("STATIC_URL", "https://example.com/static")
-	t.Setenv("LICENSE_KEY", "")
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -330,8 +387,8 @@ func TestNewConfig_StaticURL(t *testing.T) {
 }
 
 func TestNewConfig_StaticURL_Empty(t *testing.T) {
-	t.Setenv("STATIC_URL", "")
-	t.Setenv("LICENSE_KEY", "")
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -339,7 +396,8 @@ func TestNewConfig_StaticURL_Empty(t *testing.T) {
 }
 
 func TestNewConfig_SummarizerDefaults(t *testing.T) {
-	t.Setenv("LICENSE_KEY", "")
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -355,7 +413,8 @@ func TestNewConfig_SummarizerDefaults(t *testing.T) {
 }
 
 func TestNewConfig_SearchEngineDefaults(t *testing.T) {
-	t.Setenv("LICENSE_KEY", "")
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -440,7 +499,8 @@ func TestEnsureInstallationID_ReplacesInvalidFileContent(t *testing.T) {
 }
 
 func TestNewConfig_CorsOrigins(t *testing.T) {
-	t.Setenv("LICENSE_KEY", "")
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
 
 	config, err := NewConfig()
 	require.NoError(t, err)
@@ -449,7 +509,8 @@ func TestNewConfig_CorsOrigins(t *testing.T) {
 }
 
 func TestNewConfig_OllamaDefaults(t *testing.T) {
-	t.Setenv("LICENSE_KEY", "")
+	clearConfigEnv(t)
+	t.Chdir(t.TempDir())
 
 	config, err := NewConfig()
 	require.NoError(t, err)


### PR DESCRIPTION
## Description of Change

**Problem:** The `pkg/config` package has no unit test coverage. This package handles all environment variable parsing, default values, URL parsing, and installation ID management for the entire application.

**Solution:** Add 14 unit tests covering NewConfig defaults, environment variable overrides, URL parsing, provider server URL defaults, summarizer settings, search engine defaults, and all ensureInstallationID code paths (UUID generation, file read/write, invalid value handling).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security update
- [x] Test update
- [ ] Documentation update
- [ ] Configuration change

## Areas Affected

- [x] Core Services (Frontend UI / Backend API)
- [ ] AI Agents (Researcher / Developer / Executor)
- [ ] Security Tools Integration
- [ ] Memory System (Vector Store / Knowledge Base)
- [ ] Monitoring Stack (Grafana / OpenTelemetry)
- [ ] Analytics & Reporting
- [ ] External Integrations (LLM Providers / Search Engines / Security APIs)
- [ ] Documentation
- [ ] Infrastructure / DevOps

## Testing and Verification

### Test Configuration
- PentAGI Version: v1.2.0 (master)
- Go Version: 1.24.1
- Host OS: Windows 11

### Test Steps
1. Run `go test ./pkg/config/... -v`

### Test Results
```
=== RUN   TestNewConfig_Defaults
--- PASS: TestNewConfig_Defaults (0.00s)
=== RUN   TestNewConfig_EnvOverride
--- PASS: TestNewConfig_EnvOverride (0.00s)
=== RUN   TestNewConfig_ProviderDefaults
--- PASS: TestNewConfig_ProviderDefaults (0.00s)
=== RUN   TestNewConfig_StaticURL
--- PASS: TestNewConfig_StaticURL (0.00s)
=== RUN   TestNewConfig_StaticURL_Empty
--- PASS: TestNewConfig_StaticURL_Empty (0.00s)
=== RUN   TestNewConfig_SummarizerDefaults
--- PASS: TestNewConfig_SummarizerDefaults (0.00s)
=== RUN   TestNewConfig_SearchEngineDefaults
--- PASS: TestNewConfig_SearchEngineDefaults (0.00s)
=== RUN   TestEnsureInstallationID_GeneratesNewUUID
--- PASS: TestEnsureInstallationID_GeneratesNewUUID (0.02s)
=== RUN   TestEnsureInstallationID_ReadsExistingFile
--- PASS: TestEnsureInstallationID_ReadsExistingFile (0.01s)
=== RUN   TestEnsureInstallationID_KeepsValidEnvValue
--- PASS: TestEnsureInstallationID_KeepsValidEnvValue (0.00s)
=== RUN   TestEnsureInstallationID_ReplacesInvalidEnvValue
--- PASS: TestEnsureInstallationID_ReplacesInvalidEnvValue (0.00s)
=== RUN   TestEnsureInstallationID_ReplacesInvalidFileContent
--- PASS: TestEnsureInstallationID_ReplacesInvalidFileContent (0.01s)
=== RUN   TestNewConfig_CorsOrigins
--- PASS: TestNewConfig_CorsOrigins (0.00s)
=== RUN   TestNewConfig_OllamaDefaults
--- PASS: TestNewConfig_OllamaDefaults (0.00s)
PASS
ok  	pentagi/pkg/config	3.855s
```

## Checklist

- [x] Code follows project coding standards
- [x] Tests added for changes
- [x] All tests pass
- [x] `go fmt` and `go vet` run
- [x] Changes are backward compatible