### PR TITLE
fix(system): add configurable timeout to HTTP client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,10 @@ PROXY_URL=
 EXTERNAL_SSL_CA_PATH=
 EXTERNAL_SSL_INSECURE=
 
+## HTTP client timeout in seconds for external API calls (LLM providers, search tools, etc.)
+## Default: 600 (10 minutes). Set to 0 to use the default.
+HTTP_CLIENT_TIMEOUT=600
+
 ## Scraper URLs and settings
 ## For Docker (default):
 SCRAPER_PUBLIC_URL=

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -190,6 +190,10 @@ type Config struct {
 	ExternalSSLCAPath   string `env:"EXTERNAL_SSL_CA_PATH" envDefault:""`
 	ExternalSSLInsecure bool   `env:"EXTERNAL_SSL_INSECURE" envDefault:"false"`
 
+	// HTTP client timeout in seconds for external API calls (LLM providers, search tools, etc.)
+	// A value of 0 means no timeout (not recommended).
+	HTTPClientTimeout int `env:"HTTP_CLIENT_TIMEOUT" envDefault:"600"`
+
 	// Telemetry (observability OpenTelemetry collector)
 	TelemetryEndpoint string `env:"OTEL_HOST"`
 

--- a/backend/pkg/system/utils.go
+++ b/backend/pkg/system/utils.go
@@ -8,8 +8,14 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"pentagi/pkg/config"
+)
+
+const (
+	// defaultHTTPClientTimeout is the fallback timeout when no config is provided.
+	defaultHTTPClientTimeout = 10 * time.Minute
 )
 
 func getHostname() string {
@@ -65,7 +71,9 @@ func GetHTTPClient(cfg *config.Config) (*http.Client, error) {
 	var httpClient *http.Client
 
 	if cfg == nil {
-		return http.DefaultClient, nil
+		return &http.Client{
+			Timeout: defaultHTTPClientTimeout,
+		}, nil
 	}
 
 	rootCAPool, err := GetSystemCertPool(cfg)
@@ -73,8 +81,14 @@ func GetHTTPClient(cfg *config.Config) (*http.Client, error) {
 		return nil, err
 	}
 
+	timeout := defaultHTTPClientTimeout
+	if cfg.HTTPClientTimeout > 0 {
+		timeout = time.Duration(cfg.HTTPClientTimeout) * time.Second
+	}
+
 	if cfg.ProxyURL != "" {
 		httpClient = &http.Client{
+			Timeout: timeout,
 			Transport: &http.Transport{
 				Proxy: func(req *http.Request) (*url.URL, error) {
 					return url.Parse(cfg.ProxyURL)
@@ -87,6 +101,7 @@ func GetHTTPClient(cfg *config.Config) (*http.Client, error) {
 		}
 	} else {
 		httpClient = &http.Client{
+			Timeout: timeout,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					RootCAs:            rootCAPool,

--- a/backend/pkg/system/utils_test.go
+++ b/backend/pkg/system/utils_test.go
@@ -211,6 +211,7 @@ func createTestConfig(caPath string, insecure bool, proxyURL string) *config.Con
 		ExternalSSLCAPath:   caPath,
 		ExternalSSLInsecure: insecure,
 		ProxyURL:            proxyURL,
+		HTTPClientTimeout:   600, // default 10 minutes
 	}
 }
 
@@ -632,6 +633,83 @@ func TestHTTPClient_RealConnection_MultipleRootCAs(t *testing.T) {
 
 	if resp2.StatusCode != http.StatusOK {
 		t.Errorf("expected status 200 from second server, got %d", resp2.StatusCode)
+	}
+}
+
+func TestGetHTTPClient_NilConfig(t *testing.T) {
+	client, err := GetHTTPClient(nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("expected non-nil HTTP client")
+	}
+
+	if client.Timeout != defaultHTTPClientTimeout {
+		t.Errorf("expected default timeout %v, got %v", defaultHTTPClientTimeout, client.Timeout)
+	}
+}
+
+func TestGetHTTPClient_DefaultTimeout(t *testing.T) {
+	cfg := createTestConfig("", false, "")
+
+	client, err := GetHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	expected := 600 * time.Second
+	if client.Timeout != expected {
+		t.Errorf("expected timeout %v, got %v", expected, client.Timeout)
+	}
+}
+
+func TestGetHTTPClient_CustomTimeout(t *testing.T) {
+	cfg := &config.Config{
+		HTTPClientTimeout: 120,
+	}
+
+	client, err := GetHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	expected := 120 * time.Second
+	if client.Timeout != expected {
+		t.Errorf("expected timeout %v, got %v", expected, client.Timeout)
+	}
+}
+
+func TestGetHTTPClient_ZeroTimeoutUsesDefault(t *testing.T) {
+	cfg := &config.Config{
+		HTTPClientTimeout: 0,
+	}
+
+	client, err := GetHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if client.Timeout != defaultHTTPClientTimeout {
+		t.Errorf("expected default timeout %v for zero config, got %v", defaultHTTPClientTimeout, client.Timeout)
+	}
+}
+
+func TestGetHTTPClient_TimeoutWithProxy(t *testing.T) {
+	cfg := &config.Config{
+		HTTPClientTimeout: 300,
+		ProxyURL:          "http://proxy.example.com:8080",
+	}
+
+	client, err := GetHTTPClient(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	expected := 300 * time.Second
+	if client.Timeout != expected {
+		t.Errorf("expected timeout %v with proxy, got %v", expected, client.Timeout)
 	}
 }
 


### PR DESCRIPTION
## Summary

`GetHTTPClient` in `system/utils.go` creates `http.Client` instances **without a `Timeout` field**. When an external API (LLM provider, search tool, scraper, etc.) stops responding or hangs, the calling goroutine blocks indefinitely — leading to goroutine leaks and eventual resource exhaustion.

This affects **all 17 call sites** across the codebase:
- Every LLM provider: OpenAI, Anthropic, Gemini, DeepSeek, Kimi, Qwen, GLM, Ollama, custom
- All search tools: Tavily, DuckDuckGo, Sploitus, Perplexity, Google, Traversaal, SearxNG
- Embeddings provider

## Changes

| File | Change |
|------|--------|
| `backend/pkg/config/config.go` | Add `HTTPClientTimeout` config field (`HTTP_CLIENT_TIMEOUT` env var, default 600s) |
| `backend/pkg/system/utils.go` | Set `Timeout` on all `http.Client` instances; use default timeout for nil config |
| `backend/pkg/system/utils_test.go` | Add 5 tests: default, custom, zero-fallback, nil-config, and proxy scenarios |
| `.env.example` | Document the new `HTTP_CLIENT_TIMEOUT` env var |

## Design Decisions

- **Default: 10 minutes (600s)** — long enough for slow LLM responses (large context, complex reasoning), short enough to catch genuinely hung connections.
- **Configurable via env var** — operators can tune per deployment. Users behind slow proxies or running local Ollama with large models may need longer.
- **Zero = use default** — setting `HTTP_CLIENT_TIMEOUT=0` falls back to the 10-minute default rather than disabling timeouts entirely, preventing accidental infinite hangs.
- **Nil config gets a timeout too** — previously returned `http.DefaultClient` (no timeout); now returns a client with the default timeout.

## Relation to Existing Issues

This is a contributing factor to #176 (agent delegation context canceled). While #195 addresses the detached command context issue, the underlying HTTP client still has no timeout — meaning a hanging LLM API call will block the goroutine forever even after the context fix.

## Testing

Added 5 unit tests:
- `TestGetHTTPClient_NilConfig` — nil config returns client with default timeout
- `TestGetHTTPClient_DefaultTimeout` — config with default value (600s)
- `TestGetHTTPClient_CustomTimeout` — config with custom value (120s)
- `TestGetHTTPClient_ZeroTimeoutUsesDefault` — zero falls back to default
- `TestGetHTTPClient_TimeoutWithProxy` — timeout applies with proxy configured

## Verification

- [x] Changes are backward-compatible (default matches current behavior for non-hanging requests)
- [x] No breaking changes to existing callers (all use `GetHTTPClient` → automatically get timeout)
- [x] `.env.example` updated with documentation