### PR TITLE
fix: initialize buildMonitor in NewAssistantProvider and LoadAssistantProvider

### DIFF
--- a/backend/pkg/providers/providers.go
+++ b/backend/pkg/providers/providers.go
@@ -597,7 +597,16 @@ func (pc *providerController) NewAssistantProvider(
 			prompter:       prompter,
 			executor:       executor,
 			streamCb:       streamCb,
-			summarizer:     pc.summarizerAgent,
+			summarizer:      pc.summarizerAgent,
+			maxGACallsLimit: pc.cfg.MaxGeneralAgentToolCalls,
+			maxLACallsLimit: pc.cfg.MaxLimitedAgentToolCalls,
+			buildMonitor: func() *executionMonitor {
+				return &executionMonitor{
+					enabled:        pc.cfg.ExecutionMonitorEnabled,
+					sameThreshold:  pc.cfg.ExecutionMonitorSameToolLimit,
+					totalThreshold: pc.cfg.ExecutionMonitorTotalToolLimit,
+				}
+			},
 			Provider:       prv,
 		},
 	}
@@ -640,7 +649,16 @@ func (pc *providerController) LoadAssistantProvider(
 			prompter:       prompter,
 			executor:       executor,
 			streamCb:       streamCb,
-			summarizer:     pc.summarizerAgent,
+			summarizer:      pc.summarizerAgent,
+			maxGACallsLimit: pc.cfg.MaxGeneralAgentToolCalls,
+			maxLACallsLimit: pc.cfg.MaxLimitedAgentToolCalls,
+			buildMonitor: func() *executionMonitor {
+				return &executionMonitor{
+					enabled:        pc.cfg.ExecutionMonitorEnabled,
+					sameThreshold:  pc.cfg.ExecutionMonitorSameToolLimit,
+					totalThreshold: pc.cfg.ExecutionMonitorTotalToolLimit,
+				}
+			},
 			Provider:       prv,
 		},
 	}


### PR DESCRIPTION
## Problem

Commit `df92de11` ("feat: enhance agent supervision with execution monitoring and task planning") introduced the `buildMonitor` field to `flowProvider` and correctly initialized it in `NewFlowProvider` and `LoadFlowProvider`. However, the same initialization was **missing** from `NewAssistantProvider` and `LoadAssistantProvider`.

This causes a **nil pointer dereference panic** every time an assistant flow is started, because `performAgentChain` unconditionally calls `fp.buildMonitor()` on line 62 of `performer.go`:

```go
monitor = fp.buildMonitor() // panics if buildMonitor is nil
```

The panic kills the goroutine and the assistant returns no output. This affects **all LLM providers** (OpenAI, Groq, Ollama, OpenRouter, etc.) when using assistant-mode flows.

## Root cause

`NewFlowProvider` and `LoadFlowProvider` both set:

```go
maxGACallsLimit: pc.cfg.MaxGeneralAgentToolCalls,
maxLACallsLimit: pc.cfg.MaxLimitedAgentToolCalls,
buildMonitor: func() *executionMonitor {
    return &executionMonitor{
        enabled:        pc.cfg.ExecutionMonitorEnabled,
        sameThreshold:  pc.cfg.ExecutionMonitorSameToolLimit,
        totalThreshold: pc.cfg.ExecutionMonitorTotalToolLimit,
    }
},
```

But `NewAssistantProvider` and `LoadAssistantProvider` did not include these fields, leaving `buildMonitor` as `nil`.

## Fix

Added the missing `maxGACallsLimit`, `maxLACallsLimit`, and `buildMonitor` initializations to both `NewAssistantProvider` and `LoadAssistantProvider` in `providers.go`, matching the pattern already used in the flow provider constructors.

## Testing

Verified by deploying the patched build — assistant flows that previously panicked immediately now execute correctly through the full agent chain.