### PR TITLE
test: add unit tests for graphiti client disabled mode

### DIFF
--- a/backend/pkg/graphiti/client_test.go
+++ b/backend/pkg/graphiti/client_test.go
@@ -1,0 +1,133 @@
+package graphiti
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient_Disabled(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient("", 0, false)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.False(t, client.IsEnabled())
+}
+
+func TestIsEnabled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil receiver returns false", func(t *testing.T) {
+		t.Parallel()
+		var c *Client
+		assert.False(t, c.IsEnabled())
+	})
+
+	t.Run("disabled client returns false", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{enabled: false}
+		assert.False(t, c.IsEnabled())
+	})
+
+	t.Run("enabled client returns true", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{enabled: true}
+		assert.True(t, c.IsEnabled())
+	})
+}
+
+func TestGetTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil receiver returns zero", func(t *testing.T) {
+		t.Parallel()
+		var c *Client
+		assert.Equal(t, time.Duration(0), c.GetTimeout())
+	})
+
+	t.Run("returns configured timeout", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{timeout: 30 * time.Second}
+		assert.Equal(t, 30*time.Second, c.GetTimeout())
+	})
+}
+
+func TestAddMessages_Disabled(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient("", 0, false)
+	require.NoError(t, err)
+
+	err = client.AddMessages(context.Background(), AddMessagesRequest{})
+	assert.NoError(t, err)
+}
+
+func TestSearchMethods_Disabled(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient("", 0, false)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		fn   func() (any, error)
+	}{
+		{
+			"TemporalWindowSearch",
+			func() (any, error) {
+				return client.TemporalWindowSearch(context.Background(), TemporalSearchRequest{})
+			},
+		},
+		{
+			"EntityRelationshipsSearch",
+			func() (any, error) {
+				return client.EntityRelationshipsSearch(context.Background(), EntityRelationshipSearchRequest{})
+			},
+		},
+		{
+			"DiverseResultsSearch",
+			func() (any, error) {
+				return client.DiverseResultsSearch(context.Background(), DiverseSearchRequest{})
+			},
+		},
+		{
+			"EpisodeContextSearch",
+			func() (any, error) {
+				return client.EpisodeContextSearch(context.Background(), EpisodeContextSearchRequest{})
+			},
+		},
+		{
+			"SuccessfulToolsSearch",
+			func() (any, error) {
+				return client.SuccessfulToolsSearch(context.Background(), SuccessfulToolsSearchRequest{})
+			},
+		},
+		{
+			"RecentContextSearch",
+			func() (any, error) {
+				return client.RecentContextSearch(context.Background(), RecentContextSearchRequest{})
+			},
+		},
+		{
+			"EntityByLabelSearch",
+			func() (any, error) {
+				return client.EntityByLabelSearch(context.Background(), EntityByLabelSearchRequest{})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp, err := tt.fn()
+			assert.Nil(t, resp)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "graphiti is not enabled")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests for `backend/pkg/graphiti/client.go`
- Cover disabled-mode behavior for `NewClient`, `IsEnabled`, `GetTimeout`, `AddMessages`, and all search methods
- Keep scope hermetic and test-only without introducing a fake Graphiti server

## Test Coverage

Covered:
- `NewClient(..., enabled=false)`
- `(*Client).IsEnabled`
- `(*Client).GetTimeout`
- `(*Client).AddMessages`
- `(*Client).TemporalWindowSearch`
- `(*Client).EntityRelationshipsSearch`
- `(*Client).DiverseResultsSearch`
- `(*Client).EpisodeContextSearch`
- `(*Client).SuccessfulToolsSearch`
- `(*Client).RecentContextSearch`
- `(*Client).EntityByLabelSearch`

Behavior verified:
- disabled client is created without error
- nil/disabled/enabled state handling is correct
- disabled `AddMessages` is a no-op
- disabled search methods return nil response and an error containing `graphiti is not enabled`

## Scope Notes

- Enabled-path network behavior is intentionally not tested
- Testing the real enabled path would require a fake Graphiti server and would make this PR broader than intended

## Test Plan

- [x] `go test ./pkg/graphiti/... -count=1`
- [x] `go test ./pkg/graphiti/... -count=1 -shuffle=on`
- [x] `go vet ./pkg/graphiti/...`