### PR TITLE
fix: align compose checks with docker compose

### DIFF
--- a/backend/cmd/installer/checker/helpers.go
+++ b/backend/cmd/installer/checker/helpers.go
@@ -236,14 +236,15 @@ func checkDockerCliVersion() DockerVersion {
 }
 
 func checkDockerComposeVersion() DockerVersion {
-	cmd := exec.Command("docker", "compose", "version")
-	output, err := cmd.Output()
+	return checkDockerComposeVersionWithRunner(func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).Output()
+	})
+}
+
+func checkDockerComposeVersionWithRunner(run func(name string, args ...string) ([]byte, error)) DockerVersion {
+	output, err := run("docker", "compose", "version")
 	if err != nil {
-		cmd = exec.Command("docker-compose", "--version")
-		output, err = cmd.Output()
-		if err != nil {
-			return DockerVersion{Version: "", Valid: false}
-		}
+		return DockerVersion{Version: "", Valid: false}
 	}
 
 	versionStr := extractVersionFromOutput(string(output))

--- a/backend/cmd/installer/checker/helpers.go
+++ b/backend/cmd/installer/checker/helpers.go
@@ -243,7 +243,7 @@ func checkDockerComposeVersion() DockerVersion {
 
 func checkDockerComposeVersionWithRunner(run func(name string, args ...string) ([]byte, error)) DockerVersion {
 	output, err := run("docker", "compose", "version")
-	if err != nil {
+	if err != nil && len(output) == 0 {
 		return DockerVersion{Version: "", Valid: false}
 	}
 

--- a/backend/cmd/installer/checker/helpers_test.go
+++ b/backend/cmd/installer/checker/helpers_test.go
@@ -184,6 +184,24 @@ func TestCheckDockerComposeVersionWithRunner(t *testing.T) {
 		}
 	})
 
+	t.Run("parses version from stdout even when error is returned", func(t *testing.T) {
+		calls := 0
+		result := checkDockerComposeVersionWithRunner(func(name string, args ...string) ([]byte, error) {
+			calls++
+			return []byte("Docker Compose version v2.12.2"), errors.New("exit status 1")
+		})
+
+		if calls != 1 {
+			t.Fatalf("expected 1 command invocation, got %d", calls)
+		}
+		if result.Version != "2.12.2" {
+			t.Fatalf("expected version 2.12.2, got %q", result.Version)
+		}
+		if !result.Valid {
+			t.Fatal("expected docker compose version to remain valid when stdout is parseable")
+		}
+	})
+
 	t.Run("fails when docker compose is unavailable", func(t *testing.T) {
 		calls := 0
 		result := checkDockerComposeVersionWithRunner(func(name string, args ...string) ([]byte, error) {

--- a/backend/cmd/installer/checker/helpers_test.go
+++ b/backend/cmd/installer/checker/helpers_test.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -155,6 +156,51 @@ func TestExtractVersionFromOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckDockerComposeVersionWithRunner(t *testing.T) {
+	t.Run("uses docker compose v2 output", func(t *testing.T) {
+		calls := 0
+		result := checkDockerComposeVersionWithRunner(func(name string, args ...string) ([]byte, error) {
+			calls++
+			if name != "docker" {
+				t.Fatalf("unexpected command %q", name)
+			}
+			if len(args) != 2 || args[0] != "compose" || args[1] != "version" {
+				t.Fatalf("unexpected args: %v", args)
+			}
+
+			return []byte("Docker Compose version v2.12.2"), nil
+		})
+
+		if calls != 1 {
+			t.Fatalf("expected 1 command invocation, got %d", calls)
+		}
+		if result.Version != "2.12.2" {
+			t.Fatalf("expected version 2.12.2, got %q", result.Version)
+		}
+		if !result.Valid {
+			t.Fatal("expected docker compose version to be valid")
+		}
+	})
+
+	t.Run("fails when docker compose is unavailable", func(t *testing.T) {
+		calls := 0
+		result := checkDockerComposeVersionWithRunner(func(name string, args ...string) ([]byte, error) {
+			calls++
+			return nil, errors.New("executable file not found")
+		})
+
+		if calls != 1 {
+			t.Fatalf("expected 1 command invocation, got %d", calls)
+		}
+		if result.Version != "" {
+			t.Fatalf("expected empty version, got %q", result.Version)
+		}
+		if result.Valid {
+			t.Fatal("expected docker compose check to be invalid")
+		}
+	})
 }
 
 func TestCheckVersionCompatibility(t *testing.T) {

--- a/backend/cmd/installer/wizard/locale/locale.go
+++ b/backend/cmd/installer/wizard/locale/locale.go
@@ -155,23 +155,27 @@ Required: 20.0.0+`
 
 	// Docker Compose issues
 	TroubleshootComposeTitle = "Docker Compose Not Found"
-	TroubleshootComposeDesc  = "Docker Compose is required but not installed or not in PATH."
+	TroubleshootComposeDesc  = "The Docker Compose v2 plugin is required, but `docker compose` is not available."
 	TroubleshootComposeFix   = `To fix:
-1. Install Docker Desktop (includes Compose) or
-2. Install standalone: https://docs.docker.com/compose/install/
+1. Install or update Docker Desktop, or install the Docker Compose v2 plugin for Docker Engine
+2. Verify the plugin is available: docker compose version
+3. If only legacy docker-compose is installed, remove it or install the v2 plugin as well
 
-Verify installation: docker compose version`
+PentAGI executes "docker compose", so legacy "docker-compose" alone is not sufficient.
+Documentation: https://docs.docker.com/compose/install/`
 
 	// Docker Compose version issues
 	TroubleshootComposeVersionTitle = "Docker Compose Version Too Old"
-	TroubleshootComposeVersionDesc  = "Your Docker Compose version is incompatible. PentAGI requires Docker Compose 1.25.0 or newer."
+	TroubleshootComposeVersionDesc  = "Your `docker compose` version is incompatible. PentAGI requires Docker Compose 1.25.0 or newer."
 	TroubleshootComposeVersionFix   = `Current version: %s
 Required: 1.25.0+
 
 To fix:
-1. Update Docker Desktop to latest version
-2. Or install newer Docker Compose:
-   https://docs.docker.com/compose/install/`
+1. Update Docker Desktop or the Docker Compose v2 plugin to a newer version
+2. Verify the result with: docker compose version
+3. If only legacy docker-compose is installed, install the v2 plugin as well
+
+Documentation: https://docs.docker.com/compose/install/`
 
 	// Worker environment issues
 	TroubleshootWorkerTitle = "Worker Docker Environment Not Accessible"


### PR DESCRIPTION
## Summary

- remove the install-time fallback to legacy `docker-compose --version`
- align Docker Compose validation with the actual installer execution path, which already uses `docker compose`
- add unit coverage for the compose version check and update troubleshooting text accordingly

## Problem

Issue #254 reports installation trouble on Windows, and the current installer logic contains a confusing mismatch.

The checker accepts either `docker compose version` or legacy `docker-compose --version`, but the processor later executes only `docker compose ...`. That means the preflight check can succeed in environments where the actual install command will still fail.

## Solution

Make the checker validate the same command path that PentAGI actually uses at runtime.

- `checkDockerComposeVersion()` now treats `docker compose version` as the only source of truth
- a small testable helper was added so the compose validation path can be unit tested without shelling out in tests
- installer troubleshooting text now explains that PentAGI requires the Docker Compose v2 plugin and that legacy `docker-compose` alone is not enough

This keeps the fix narrowly focused on validation/runtime alignment without changing the existing minimum version policy or the compose processor itself.

## User Impact

Users now get an earlier and more accurate failure when the Docker Compose v2 plugin is missing, instead of passing preflight checks and failing later during execution. The installer guidance is also clearer about what needs to be installed.

Closes #254.

## Test Plan

- [x] `go test ./cmd/installer/checker/... -run 'TestCheckDockerComposeVersionWithRunner|TestExtractVersionFromOutput|TestCheckVersionCompatibility'`
- [x] `go test ./cmd/installer/wizard/locale`
- [x] `git diff --check`

## Notes

`go test ./cmd/installer/checker/...` still fails on this Windows host because of a pre-existing `TestCheckFileExistsAndReadable` issue unrelated to this PR. The targeted compose/version tests added in this change pass successfully.
