### PR TITLE
[codex] docs: clarify current PentAGI capability boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ You can watch the video **PentAGI overview**:
 - API Token Authentication. Secure Bearer token system for programmatic access to REST and GraphQL APIs.
 - Quick Deployment. Easy setup through [Docker Compose](https://docs.docker.com/compose/) with comprehensive environment configuration.
 
+### Current Capability Boundaries
+
+- PentAGI today is an autonomous and assistant-guided penetration testing platform, not a CALDERA-style Breach and Attack Simulation (BAS) or adversary emulation product with predefined campaigns or attack plans.
+- BAS-like agent-authored attack scripts should be treated as conceptual or future work, not as a feature that is implemented today.
+- The current flow report UI supports web view, copy to clipboard, Markdown download, and PDF download. JSON flow-report export is not documented as a supported output format today.
+- Provider flexibility is available today through built-in providers and custom/OpenAI-compatible endpoints. See [Custom LLM Provider Configuration](#custom-llm-provider-configuration) and the [vLLM + Qwen3.5-27B-FP8 guide](examples/guides/vllm-qwen35-27b-fp8.md).
+
 ## Architecture
 
 ### System Context


### PR DESCRIPTION
### Summary
- adds a short `Current Capability Boundaries` section to `README.md`
- clarifies what PentAGI supports today versus what is still conceptual
- points readers to the existing reporting and provider docs instead of implying unsupported BAS-style workflows or JSON flow-report export

### Problem
Issue #35 asks whether PentAGI already supports internal pentest / BAS-like workflows, specific report outputs, and flexible provider setup. The repo already contains pieces of that answer, but the README did not state the current capability boundaries in one place, which makes it easy to over-assume what is available today.

Related to #35.

### Solution
- add a focused README clarification right after the Features section
- state that PentAGI is an autonomous and assistant-guided pentesting platform, not a CALDERA-style BAS or predefined adversary emulation product
- describe BAS-like agent-authored attack scripts as conceptual or future work, not an implemented feature
- document the current flow report UI reality: web view, copy to clipboard, Markdown download, and PDF download
- point readers to the existing custom/OpenAI-compatible provider configuration docs and the vLLM guide

### User Impact
- sets clearer expectations for users evaluating PentAGI for internal pentest or BAS-style use cases
- reduces confusion around what reporting/export options are available right now
- makes provider flexibility easier to discover from the main README

### Test Plan
- verified maintainer guidance in issue #35 before drafting the wording
- verified OpenAI-compatible endpoint support in `README.md` and `backend/docs/llms_how_to.md`
- verified current flow report UI actions in `frontend/src/pages/flows/flow.tsx`
- verified no documented JSON flow-report export for flow reports
- ran `git diff --check`
