### PR TITLE
docs: clarify current web settings coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,24 @@ The installer will:
 5. **Security Hardening**: Generate secure credentials and configure SSL certificates
 6. **Deployment**: Start PentAGI with docker-compose
 
+### Current Web Settings Coverage
+
+The PentAGI web console already manages several settings areas after the server is up and running:
+
+- **Settings -> Providers**: Create, edit, delete, and test user-defined provider profiles for supported provider types. These profiles control per-agent model selection, runtime parameters, reasoning options, and pricing metadata.
+- **Settings -> Prompts**: Manage system, human, and tool prompt templates.
+- **Settings -> API Tokens**: Create and manage PentAGI Bearer tokens for REST and GraphQL access.
+- **Other UI-managed preferences**: Favorite flows are stored as user preferences, and theme selection is handled from the main sidebar/profile controls rather than the Settings pages.
+
+### Still Server-Managed
+
+The following configuration areas still need to be set on the server through environment variables, compose files, or mounted config files:
+
+- **LLM credentials and connection details**: API keys, endpoints, auth modes, and config-path settings such as `OPEN_AI_KEY`, `ANTHROPIC_API_KEY`, `BEDROCK_*`, `OLLAMA_SERVER_*`, and `LLM_SERVER_*`.
+- **Search provider credentials and options**: Settings such as `DUCKDUCKGO_*`, `GOOGLE_*`, `TAVILY_API_KEY`, `TRAVERSAAL_API_KEY`, `PERPLEXITY_*`, `SEARXNG_*`, and `SPLOITUS_ENABLED`.
+- **Third-party integrations**: Langfuse, Graphiti, and similar external services remain server-side configuration.
+- **MCP server management**: MCP settings pages are not currently exposed as a live web-console feature.
+
 **For Production & Enhanced Security:**
 
 For production deployments or security-sensitive environments, we **strongly recommend** using a distributed two-node architecture where worker operations are isolated on a separate server. This prevents untrusted code execution and network access issues on your main system.

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ The PentAGI web console already manages several settings areas after the server 
 
 The following configuration areas still need to be set on the server through environment variables, compose files, or mounted config files:
 
-- **LLM credentials and connection details**: API keys, endpoints, auth modes, and config-path settings such as `OPEN_AI_KEY`, `ANTHROPIC_API_KEY`, `BEDROCK_*`, `OLLAMA_SERVER_*`, and `LLM_SERVER_*`.
+- **LLM credentials and connection details**: API keys, endpoints, auth modes, and provider-specific connection settings for OpenAI, Anthropic, Bedrock, Ollama, custom providers, and similar backends; config-path settings apply only where supported, such as `OLLAMA_SERVER_CONFIG_PATH` and `LLM_SERVER_CONFIG_PATH`.
 - **Search provider credentials and options**: Settings such as `DUCKDUCKGO_*`, `GOOGLE_*`, `TAVILY_API_KEY`, `TRAVERSAAL_API_KEY`, `PERPLEXITY_*`, `SEARXNG_*`, and `SPLOITUS_ENABLED`.
 - **Third-party integrations**: Langfuse, Graphiti, and similar external services remain server-side configuration.
 - **MCP server management**: MCP settings pages are not currently exposed as a live web-console feature.

--- a/backend/docs/config.md
+++ b/backend/docs/config.md
@@ -7,6 +7,8 @@ This document serves as a comprehensive guide to the configuration system in Pen
 - [PentAGI Configuration Guide](#pentagi-configuration-guide)
   - [Table of Contents](#table-of-contents)
   - [Configuration Basics](#configuration-basics)
+    - [Current Web Settings Coverage](#current-web-settings-coverage)
+    - [Still Server-Managed](#still-server-managed)
   - [General Settings](#general-settings)
     - [Usage Details](#usage-details)
   - [Docker Settings](#docker-settings)
@@ -100,6 +102,26 @@ func NewConfig() (*Config, error) {
 ```
 
 This function automatically loads environment variables from a `.env` file if present, then parses them into the `Config` struct using the `env` package from `github.com/caarlos0/env/v10`.
+
+### Current Web Settings Coverage
+
+The running PentAGI instance already exposes several settings areas in the web UI:
+
+- **Settings -> Providers**: Manage user-defined provider profiles, per-agent model and runtime options, and provider test actions for provider types supported by the running server.
+- **Settings -> Prompts**: Manage system, human, and tool prompt templates.
+- **Settings -> API Tokens**: Create, revoke, and delete PentAGI API tokens.
+- **Other UI-managed preferences**: Favorite flows are stored as user preferences, and theme selection is handled client-side from the main sidebar/profile controls.
+
+These web-console features do not replace the environment variables in this guide for provider credentials, endpoints, or external integrations.
+
+### Still Server-Managed
+
+The environment variables documented below remain the source of truth for configuration that is not currently editable from the web console:
+
+- **LLM credentials and connection settings**: API keys, base URLs, auth modes, and config-path values for OpenAI, Anthropic, Bedrock, Ollama, custom providers, and similar backends.
+- **Search provider credentials and options**: DuckDuckGo, Google, Tavily, Traversaal, Perplexity, Searxng, Sploitus, and related search configuration.
+- **Third-party integrations**: Langfuse, Graphiti, and other external observability or knowledge services.
+- **MCP server management**: MCP settings are not currently exposed as a live web-console feature.
 
 ## General Settings
 

--- a/backend/docs/config.md
+++ b/backend/docs/config.md
@@ -118,7 +118,7 @@ These web-console features do not replace the environment variables in this guid
 
 The environment variables documented below remain the source of truth for configuration that is not currently editable from the web console:
 
-- **LLM credentials and connection settings**: API keys, base URLs, auth modes, and config-path values for OpenAI, Anthropic, Bedrock, Ollama, custom providers, and similar backends.
+- **LLM credentials and connection settings**: API keys, base URLs, auth modes, and provider-specific connection settings for OpenAI, Anthropic, Bedrock, Ollama, custom providers, and similar backends; config-path settings apply only where supported, such as `OLLAMA_SERVER_CONFIG_PATH` and `LLM_SERVER_CONFIG_PATH`.
 - **Search provider credentials and options**: DuckDuckGo, Google, Tavily, Traversaal, Perplexity, Searxng, Sploitus, and related search configuration.
 - **Third-party integrations**: Langfuse, Graphiti, and other external observability or knowledge services.
 - **MCP server management**: MCP settings are not currently exposed as a live web-console feature.


### PR DESCRIPTION
## Summary
- clarify which settings areas are already managed in the web UI
- document which configuration still lives in environment variables, compose files, or mounted config files

## Problem
Issue #191 asks for configuration from the web console, but the current docs do not clearly separate shipped web settings from configuration that is still server-managed.

That makes it easy to overestimate current UI coverage, especially around search providers, third-party integrations, and LLM credentials or endpoint settings.

## Solution
- add a short `Current Web Settings Coverage` section to `README.md`
- add a matching clarification near the top of `backend/docs/config.md`
- explicitly distinguish provider profiles, prompts, and API tokens from server-managed credentials, search providers, third-party integrations, and MCP server setup

## User Impact
Users get a more accurate picture of what can already be configured after startup and what still has to be configured on the server.

This also makes #191 easier to treat as a follow-up on the remaining gap instead of a blind reimplementation of features that already exist.

## Test Plan
- re-checked each capability claim against the current frontend settings pages, GraphQL schema and resolvers, and config package
- ran `git diff --check`

References #191.
