### PR TITLE
docs: add macOS installer warning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,8 @@ PentAGI provides an interactive installer with a terminal-based UI for streamlin
 - **Windows**: amd64 [download](https://pentagi.com/downloads/windows/amd64/installer-latest.zip)
 - **macOS**: amd64 (Intel) [download](https://pentagi.com/downloads/darwin/amd64/installer-latest.zip) | arm64 (M-series) [download](https://pentagi.com/downloads/darwin/arm64/installer-latest.zip)
 
+> **macOS security warning:** macOS may occasionally flag downloaded installer builds even when they are signed. Download the installer only from the official PentAGI links above, choose the archive that matches your CPU architecture, and see the [installer troubleshooting guide](backend/docs/installer/installer-troubleshooting.md#macos-reports-the-installer-as-malware) before allowing the app to run.
+
 **Quick Installation (Linux amd64):**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ PentAGI provides an interactive installer with a terminal-based UI for streamlin
 - **Windows**: amd64 [download](https://pentagi.com/downloads/windows/amd64/installer-latest.zip)
 - **macOS**: amd64 (Intel) [download](https://pentagi.com/downloads/darwin/amd64/installer-latest.zip) | arm64 (M-series) [download](https://pentagi.com/downloads/darwin/arm64/installer-latest.zip)
 
-> **macOS security warning:** macOS may occasionally flag downloaded installer builds even when they are signed. Download the installer only from the official PentAGI links above, choose the archive that matches your CPU architecture, and see the [installer troubleshooting guide](backend/docs/installer/installer-troubleshooting.md#macos-reports-the-installer-as-malware) before allowing the app to run.
+> **macOS security warning:** If macOS flags a downloaded installer, use only the official PentAGI links above, choose the archive that matches your CPU architecture, verify the source before continuing, and follow the [installer troubleshooting guide](backend/docs/installer/installer-troubleshooting.md#macos-reports-the-installer-as-malware) before allowing the app to run.
 
 **Quick Installation (Linux amd64):**
 

--- a/backend/docs/installer/installer-troubleshooting.md
+++ b/backend/docs/installer/installer-troubleshooting.md
@@ -135,6 +135,24 @@ func (m *FormModel) ensureFocusVisible() {
 
 ## 🔧 **Common Issues & Solutions**
 
+### **macOS Reports the Installer as Malware**
+
+**Symptoms**: macOS blocks a downloaded PentAGI installer and reports that it may contain malware.
+
+**What is currently known**:
+- Use only the official PentAGI installer downloads linked from the project README.
+- Select the archive that matches your Mac CPU architecture: `darwin/amd64` for Intel Macs or `darwin/arm64` for Apple silicon.
+- The maintainers reported in [issue #249](https://github.com/vxcontrol/pentagi/issues/249) that the installer files are signed with the project certificate.
+- The maintainers also reported zero VirusTotal detections for the checked `arm64` and `amd64` installer builds in that issue.
+- Apple was contacted about the warning on March 24, 2026, and the project is waiting for Apple's response.
+- The warning may be related to embedded Jaeger ClickHouse plugin binaries, but that is still unconfirmed.
+
+**Recommended handling**:
+- Treat any unexpected malware warning as a reason to stop and verify the download source before continuing.
+- Re-download the installer from the official PentAGI link if the archive came from a mirror, chat attachment, or any unofficial source.
+- If you trust the official release after verification, use the normal macOS security flow to allow the installer for that one run.
+- Do not reuse an installer archive that was downloaded from an unknown source, even if its filename matches the official archive name.
+
 ### **Navigation Issues**
 
 #### **Navigation Stack Corruption**

--- a/backend/docs/installer/installer-troubleshooting.md
+++ b/backend/docs/installer/installer-troubleshooting.md
@@ -142,14 +142,13 @@ func (m *FormModel) ensureFocusVisible() {
 **What is currently known**:
 - Use only the official PentAGI installer downloads linked from the project README.
 - Select the archive that matches your Mac CPU architecture: `darwin/amd64` for Intel Macs or `darwin/arm64` for Apple silicon.
-- The maintainers reported in [issue #249](https://github.com/vxcontrol/pentagi/issues/249) that the installer files are signed with the project certificate.
-- The maintainers also reported zero VirusTotal detections for the checked `arm64` and `amd64` installer builds in that issue.
-- The maintainers reported in that issue that they contacted Apple about the warning and are waiting for a response.
+- Maintainer notes in [issue #249](https://github.com/vxcontrol/pentagi/issues/249) report that the installer files are signed with the project certificate and that the checked `arm64` and `amd64` builds had zero VirusTotal detections.
+- The maintainers have contacted Apple about the warning and are awaiting a response.
 
 **Recommended handling**:
 - Treat any unexpected malware warning as a reason to stop and verify the download source before continuing.
 - Re-download the installer from the official PentAGI link if the archive came from a mirror, chat attachment, or any unofficial source.
-- If you trust the official release after verification, try to open the installer once, then open **System Settings** -> **Privacy & Security**, scroll to the security section that says the installer was blocked, click **Open Anyway**, and confirm the follow-up prompt to allow that specific app to run.
+- If you trust the official release after verification, try to open the installer once. Then open **System Settings** -> **Privacy & Security**, find the security message that says the installer was blocked, click **Open Anyway**, and confirm the follow-up prompt to allow that specific app to run.
 - If your version of macOS shows different wording, follow Apple's guidance for opening a Mac app from an unidentified developer: <https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac>.
 - Do not reuse an installer archive that was downloaded from an unknown source, even if its filename matches the official archive name.
 

--- a/backend/docs/installer/installer-troubleshooting.md
+++ b/backend/docs/installer/installer-troubleshooting.md
@@ -144,13 +144,13 @@ func (m *FormModel) ensureFocusVisible() {
 - Select the archive that matches your Mac CPU architecture: `darwin/amd64` for Intel Macs or `darwin/arm64` for Apple silicon.
 - The maintainers reported in [issue #249](https://github.com/vxcontrol/pentagi/issues/249) that the installer files are signed with the project certificate.
 - The maintainers also reported zero VirusTotal detections for the checked `arm64` and `amd64` installer builds in that issue.
-- Apple was contacted about the warning on March 24, 2026, and the project is waiting for Apple's response.
-- The warning may be related to embedded Jaeger ClickHouse plugin binaries, but that is still unconfirmed.
+- The maintainers reported in that issue that they contacted Apple about the warning and are waiting for a response.
 
 **Recommended handling**:
 - Treat any unexpected malware warning as a reason to stop and verify the download source before continuing.
 - Re-download the installer from the official PentAGI link if the archive came from a mirror, chat attachment, or any unofficial source.
-- If you trust the official release after verification, use the normal macOS security flow to allow the installer for that one run.
+- If you trust the official release after verification, try to open the installer once, then open **System Settings** -> **Privacy & Security**, scroll to the security section that says the installer was blocked, click **Open Anyway**, and confirm the follow-up prompt to allow that specific app to run.
+- If your version of macOS shows different wording, follow Apple's guidance for opening a Mac app from an unidentified developer: <https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac>.
 - Do not reuse an installer archive that was downloaded from an unknown source, even if its filename matches the official archive name.
 
 ### **Navigation Issues**


### PR DESCRIPTION
## Summary
- add a README note for macOS installer security warnings
- document the current maintainer guidance from issue #249 in the installer troubleshooting guide
- keep the warning framed as verification guidance because the Apple-side cause is still unresolved

## Validation
- `git diff --check`
- verified the README troubleshooting anchor resolves to the new section heading

Refs #249