### PR TITLE
docs: add scope-of-work pentest template

### DIFF
--- a/backend/docs/prompt_engineering_pentagi.md
+++ b/backend/docs/prompt_engineering_pentagi.md
@@ -94,6 +94,7 @@ A comprehensive framework for designing high-performance prompts within the Pent
 
 **Security and Operational Boundaries**
 - Explicitly state the **scope** of permitted actions and **security constraints**. Reference `security-tools.mdc` for general tool security context.
+- For engagement-level boundaries, start from the reusable [scope-of-work pentest prompt template](../../examples/prompts/scope_of_work_pentest.md) and adapt the allowed targets, denied targets, stop conditions, and evidence expectations before the flow starts.
 - Define **Docker container limitations** within `<container_constraints>`, populated by template variables like `{{.DockerImage}}`, `{{.Cwd}}`, `{{.ContainerPorts}}`. Specify restrictions clearly (e.g., "No direct host access," "No GUI applications," "No UDP scanning").
 - Specify **forbidden actions** clearly. Use **ALL CAPS** for critical security warnings, permissions, or prohibitions (e.g., "DO NOT attempt to install new software packages," "ONLY execute commands related to the current SubTask").
 - Emphasize working **strictly within the scope of the current `SubTask`**. The agent must understand its current objective based on `{{.ExecutionContext}}` and not attempt actions related to other SubTasks or the overall Flow goal unless explicitly instructed within the current SubTask. Reference `data-models.mdc` and `controller.md` for task/subtask relationships.

--- a/backend/docs/prompt_engineering_pentagi.md
+++ b/backend/docs/prompt_engineering_pentagi.md
@@ -94,7 +94,7 @@ A comprehensive framework for designing high-performance prompts within the Pent
 
 **Security and Operational Boundaries**
 - Explicitly state the **scope** of permitted actions and **security constraints**. Reference `security-tools.mdc` for general tool security context.
-- For engagement-level boundaries, start from the reusable [scope-of-work pentest prompt template](../../examples/prompts/scope_of_work_pentest.md) and adapt the allowed targets, denied targets, stop conditions, and evidence expectations before the flow starts.
+- For engagement-level boundaries, start from the reusable [scope-of-work pentest prompt template](../../examples/prompts/scope_of_work_pentest.md) and adapt the allowed targets, out-of-scope targets, stop conditions, and evidence expectations before the flow starts.
 - Define **Docker container limitations** within `<container_constraints>`, populated by template variables like `{{.DockerImage}}`, `{{.Cwd}}`, `{{.ContainerPorts}}`. Specify restrictions clearly (e.g., "No direct host access," "No GUI applications," "No UDP scanning").
 - Specify **forbidden actions** clearly. Use **ALL CAPS** for critical security warnings, permissions, or prohibitions (e.g., "DO NOT attempt to install new software packages," "ONLY execute commands related to the current SubTask").
 - Emphasize working **strictly within the scope of the current `SubTask`**. The agent must understand its current objective based on `{{.ExecutionContext}}` and not attempt actions related to other SubTasks or the overall Flow goal unless explicitly instructed within the current SubTask. Reference `data-models.mdc` and `controller.md` for task/subtask relationships.

--- a/examples/prompts/scope_of_work_pentest.md
+++ b/examples/prompts/scope_of_work_pentest.md
@@ -80,7 +80,7 @@ Before every network action, command, script, scan, exploit attempt, or generate
 
 The same structure can later be converted into backend validation rules:
 
-- Store allowed targets and denied targets as normalized host, URL, IP, and CIDR entries.
+- Store allowed targets and out-of-scope targets as normalized host, URL, IP, and CIDR entries.
 - Validate command arguments before execution for tools that expose target flags or positional targets.
 - Require a per-tool policy for mass scanners, web fuzzers, exploit frameworks, and generated scripts because each expands targets differently.
 - Treat ambiguous destinations as blocked until a user or maintainer-approved policy resolves them.

--- a/examples/prompts/scope_of_work_pentest.md
+++ b/examples/prompts/scope_of_work_pentest.md
@@ -1,0 +1,87 @@
+# Scope-of-Work Pentest Prompt Template
+
+Use this template when an engagement needs explicit scope boundaries before agents start reconnaissance, scanning, exploitation, or reporting work. Replace the placeholders with the approved rules for the assessment and add the result to your reusable prompts or custom flow instructions.
+
+This template is guidance only. It does not replace legal authorization, customer approval, or future backend validation.
+
+```text
+You are operating inside an authorized security assessment. Stay strictly within the scope below.
+
+<engagement_scope>
+  <authorization_summary>
+  {{WHO_AUTHORIZED_THE_TEST}}, {{AUTHORIZATION_DATE}}, {{ENGAGEMENT_NAME_OR_TICKET}}
+  </authorization_summary>
+
+  <allowed_targets>
+  - {{EXACT_HOSTNAME_OR_URL}}
+  - {{CIDR_OR_IP_RANGE}}
+  - {{APPROVED_SUBDOMAIN_PATTERN}}
+  </allowed_targets>
+
+  <out_of_scope_targets>
+  - {{THIRD_PARTY_HOST_OR_DOMAIN}}
+  - {{PRODUCTION_SYSTEM_NOT_AUTHORIZED_FOR_TESTING}}
+  - {{SHARED_INFRASTRUCTURE_NOT_OWNED_BY_CLIENT}}
+  </out_of_scope_targets>
+
+  <allowed_actions>
+  - Passive reconnaissance against allowed targets
+  - Authenticated or unauthenticated testing explicitly requested by the user
+  - Vulnerability validation against allowed targets only
+  - Evidence collection needed for the final report
+  </allowed_actions>
+
+  <forbidden_actions>
+  - Do not test any target that is not listed or clearly derived from the allowed scope.
+  - Do not run mass scanning against broad networks unless the exact CIDR is listed in allowed_targets.
+  - Do not exploit, fuzz, brute force, or stress-test third-party services.
+  - Do not persist access, exfiltrate sensitive data, or modify data beyond the approved test plan.
+  </forbidden_actions>
+
+  <rate_limits_and_windows>
+  - {{MAX_REQUEST_RATE_OR_SCAN_SPEED}}
+  - {{APPROVED_TEST_WINDOW}}
+  - {{MAINTENANCE_OR_BLACKOUT_WINDOWS}}
+  </rate_limits_and_windows>
+
+  <credentials_and_test_accounts>
+  - {{TEST_ACCOUNT_NAME_OR_ROLE}}
+  - {{CREDENTIAL_HANDLING_RULES}}
+  </credentials_and_test_accounts>
+
+  <stop_conditions>
+  - Stop before interacting with a target that is not provably in scope.
+  - Stop if a tool expands to third-party infrastructure, shared hosting neighbors, or unrelated cloud assets.
+  - Stop if testing could cause service disruption beyond the approved limits.
+  - Stop and ask for clarification when the scope cannot be determined from the current evidence.
+  </stop_conditions>
+
+  <evidence_expectations>
+  - Record command intent, target, timestamp, and result summary for each meaningful action.
+  - Save screenshots, request/response excerpts, scan summaries, and reproduction notes under /work.
+  - Redact secrets and unrelated personal data from the final report.
+  </evidence_expectations>
+</engagement_scope>
+
+<scope_check_protocol>
+Before every network action, command, script, scan, exploit attempt, or generated tool:
+1. Extract every hostname, IP address, CIDR, URL, callback domain, and file path that could affect a target.
+2. Match each network destination against allowed_targets.
+3. Treat a destination as out of scope unless it is an exact match or a clearly authorized derivative.
+4. For tools that accept multiple targets, remove out-of-scope entries before execution.
+5. For generated scripts, validate all destination-building logic before running the script.
+6. For custom exploit development, validate the target and callback endpoints before compiling or executing anything.
+7. If a result discovers a new host, domain, bucket, tenant, or service, record it as a finding candidate but do not test it until scope is confirmed.
+8. If scope is ambiguous, stop and ask for human clarification instead of guessing.
+</scope_check_protocol>
+```
+
+## Backend Validation Ideas
+
+The same structure can later be converted into backend validation rules:
+
+- Store allowed targets and denied targets as normalized host, URL, IP, and CIDR entries.
+- Validate command arguments before execution for tools that expose target flags or positional targets.
+- Require a per-tool policy for mass scanners, web fuzzers, exploit frameworks, and generated scripts because each expands targets differently.
+- Treat ambiguous destinations as blocked until a user or maintainer-approved policy resolves them.
+- Add a reminder to the agent context after a blocked attempt so the next plan is regenerated with the scope boundary visible.


### PR DESCRIPTION
## Summary
- add a reusable scope-of-work prompt template for authorized pentest flows
- cover allowlists, denied targets, stop conditions, evidence expectations, mass scans, generated scripts, and custom exploit checks
- link the template from the PentAGI prompt engineering guide

## Validation
- `git diff --check`
- verified the prompt engineering guide link target exists

Refs #71