### PR TITLE
Add Bedrock adaptive thinking support for Claude Opus 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1751,7 +1751,7 @@ PROXY_URL=http://your-proxy:8080
 
 #### Supported Models
 
-PentAGI supports 21 AWS Bedrock models with tool calling, streaming, and multimodal capabilities. Models marked with `*` are used in default configuration.
+PentAGI supports 22 AWS Bedrock models with tool calling, streaming, and multimodal capabilities. Models marked with `*` are used in default configuration.
 
 | Model ID                                         | Provider        | Thinking | Multimodal | Price (Input/Output) | Use Case                                |
 | ------------------------------------------------ | --------------- | -------- | ---------- | -------------------- | --------------------------------------- |
@@ -1760,6 +1760,7 @@ PentAGI supports 21 AWS Bedrock models with tool calling, streaming, and multimo
 | `us.amazon.nova-pro-v1:0`                        | Amazon Nova     | ❌        | ✅          | $0.80/$3.20          | Balanced accuracy, speed, cost          |
 | `us.amazon.nova-lite-v1:0`                       | Amazon Nova     | ❌        | ✅          | $0.06/$0.24          | Fast processing, high-volume operations |
 | `us.amazon.nova-micro-v1:0`                      | Amazon Nova     | ❌        | ❌          | $0.035/$0.14         | Ultra-low latency, real-time monitoring |
+| `us.anthropic.claude-opus-4-7`                   | Anthropic       | ✅        | ✅          | $5.00/$25.00         | Latest Opus with adaptive thinking      |
 | `us.anthropic.claude-opus-4-6-v1`*               | Anthropic       | ✅        | ✅          | $5.00/$25.00         | World-class coding, enterprise agents   |
 | `us.anthropic.claude-sonnet-4-6`                 | Anthropic       | ✅        | ✅          | $3.00/$15.00         | Frontier intelligence, enterprise scale |
 | `us.anthropic.claude-opus-4-5-20251101-v1:0`     | Anthropic       | ✅        | ✅          | $5.00/$25.00         | Multi-day software development          |
@@ -1779,6 +1780,8 @@ PentAGI supports 21 AWS Bedrock models with tool calling, streaming, and multimo
 | `moonshotai.kimi-k2.5`                           | Moonshot        | ❌        | ✅          | $0.60/$3.00          | Vision, language, code in one model     |
 
 **Prices**: Per 1M tokens. Models with thinking/reasoning support additional compute costs during reasoning phase.
+
+**Reasoning Modes**: Claude Opus 4.7 on Bedrock requires Adaptive mode, and Claude Opus/Sonnet 4.6+ support it. In provider settings, select `Reasoning Mode: Adaptive` and use `Reasoning Effort` to send Bedrock `output_config.effort` instead of a fixed thinking token budget.
 
 #### Tested but Incompatible Models
 

--- a/backend/pkg/database/converter/converter.go
+++ b/backend/pkg/database/converter/converter.go
@@ -613,9 +613,13 @@ func ConvertAgentConfigToGqlModel(ac *pconfig.AgentConfig) *model.AgentConfig {
 		result.PresencePenalty = &ac.PresencePenalty
 	}
 
-	if ac.Reasoning.Effort != llms.ReasoningNone || ac.Reasoning.MaxTokens != 0 {
+	if !ac.Reasoning.IsZero() {
 		reasoning := &model.ReasoningConfig{}
 
+		if ac.Reasoning.Mode != pconfig.ReasoningModeDefault {
+			mode := model.ReasoningMode(ac.Reasoning.Mode)
+			reasoning.Mode = &mode
+		}
 		if ac.Reasoning.Effort != llms.ReasoningNone {
 			effort := model.ReasoningEffort(ac.Reasoning.Effort)
 			reasoning.Effort = &effort
@@ -708,6 +712,9 @@ func ConvertAgentConfigFromGqlModel(ac *model.AgentConfig) *pconfig.AgentConfig 
 
 	if ac.Reasoning != nil {
 		reasoning := map[string]any{}
+		if ac.Reasoning.Mode != nil {
+			reasoning["mode"] = pconfig.ReasoningMode(*ac.Reasoning.Mode)
+		}
 		if ac.Reasoning.Effort != nil {
 			reasoning["effort"] = llms.ReasoningEffort(*ac.Reasoning.Effort)
 		}

--- a/backend/pkg/graph/generated.go
+++ b/backend/pkg/graph/generated.go
@@ -458,6 +458,7 @@ type ComplexityRoot struct {
 	ReasoningConfig struct {
 		Effort    func(childComplexity int) int
 		MaxTokens func(childComplexity int) int
+		Mode      func(childComplexity int) int
 	}
 
 	Screenshot struct {
@@ -3009,6 +3010,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ReasoningConfig.MaxTokens(childComplexity), true
+
+	case "ReasoningConfig.mode":
+		if e.complexity.ReasoningConfig.Mode == nil {
+			break
+		}
+
+		return e.complexity.ReasoningConfig.Mode(childComplexity), true
 
 	case "Screenshot.createdAt":
 		if e.complexity.Screenshot.CreatedAt == nil {
@@ -8202,6 +8210,8 @@ func (ec *executionContext) fieldContext_AgentConfig_reasoning(_ context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "mode":
+				return ec.fieldContext_ReasoningConfig_mode(ctx, field)
 			case "effort":
 				return ec.fieldContext_ReasoningConfig_effort(ctx, field)
 			case "maxTokens":
@@ -21743,6 +21753,47 @@ func (ec *executionContext) fieldContext_Query___schema(_ context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _ReasoningConfig_mode(ctx context.Context, field graphql.CollectedField, obj *model.ReasoningConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ReasoningConfig_mode(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Mode, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.ReasoningMode)
+	fc.Result = res
+	return ec.marshalOReasoningMode2ᚖpentagiᚋpkgᚋgraphᚋmodelᚐReasoningMode(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ReasoningConfig_mode(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ReasoningConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ReasoningMode does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ReasoningConfig_effort(ctx context.Context, field graphql.CollectedField, obj *model.ReasoningConfig) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ReasoningConfig_effort(ctx, field)
 	if err != nil {
@@ -30891,13 +30942,20 @@ func (ec *executionContext) unmarshalInputReasoningConfigInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"effort", "maxTokens"}
+	fieldsInOrder := [...]string{"mode", "effort", "maxTokens"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "mode":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mode"))
+			data, err := ec.unmarshalOReasoningMode2ᚖpentagiᚋpkgᚋgraphᚋmodelᚐReasoningMode(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Mode = data
 		case "effort":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("effort"))
 			data, err := ec.unmarshalOReasoningEffort2ᚖpentagiᚋpkgᚋgraphᚋmodelᚐReasoningEffort(ctx, v)
@@ -34309,6 +34367,8 @@ func (ec *executionContext) _ReasoningConfig(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ReasoningConfig")
+		case "mode":
+			out.Values[i] = ec._ReasoningConfig_mode(ctx, field, obj)
 		case "effort":
 			out.Values[i] = ec._ReasoningConfig_effort(ctx, field, obj)
 		case "maxTokens":
@@ -38125,6 +38185,22 @@ func (ec *executionContext) unmarshalOReasoningEffort2ᚖpentagiᚋpkgᚋgraph�
 }
 
 func (ec *executionContext) marshalOReasoningEffort2ᚖpentagiᚋpkgᚋgraphᚋmodelᚐReasoningEffort(ctx context.Context, sel ast.SelectionSet, v *model.ReasoningEffort) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
+}
+
+func (ec *executionContext) unmarshalOReasoningMode2ᚖpentagiᚋpkgᚋgraphᚋmodelᚐReasoningMode(ctx context.Context, v interface{}) (*model.ReasoningMode, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.ReasoningMode)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOReasoningMode2ᚖpentagiᚋpkgᚋgraphᚋmodelᚐReasoningMode(ctx context.Context, sel ast.SelectionSet, v *model.ReasoningMode) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/backend/pkg/graph/model/models_gen.go
+++ b/backend/pkg/graph/model/models_gen.go
@@ -362,6 +362,7 @@ type Query struct {
 }
 
 type ReasoningConfig struct {
+	Mode      *ReasoningMode   `json:"mode,omitempty"`
 	Effort    *ReasoningEffort `json:"effort,omitempty"`
 	MaxTokens *int             `json:"maxTokens,omitempty"`
 }
@@ -946,12 +947,16 @@ func (e ProviderType) MarshalGQL(w io.Writer) {
 type ReasoningEffort string
 
 const (
+	ReasoningEffortXhigh  ReasoningEffort = "xhigh"
+	ReasoningEffortMax    ReasoningEffort = "max"
 	ReasoningEffortHigh   ReasoningEffort = "high"
 	ReasoningEffortMedium ReasoningEffort = "medium"
 	ReasoningEffortLow    ReasoningEffort = "low"
 )
 
 var AllReasoningEffort = []ReasoningEffort{
+	ReasoningEffortXhigh,
+	ReasoningEffortMax,
 	ReasoningEffortHigh,
 	ReasoningEffortMedium,
 	ReasoningEffortLow,
@@ -959,7 +964,7 @@ var AllReasoningEffort = []ReasoningEffort{
 
 func (e ReasoningEffort) IsValid() bool {
 	switch e {
-	case ReasoningEffortHigh, ReasoningEffortMedium, ReasoningEffortLow:
+	case ReasoningEffortXhigh, ReasoningEffortMax, ReasoningEffortHigh, ReasoningEffortMedium, ReasoningEffortLow:
 		return true
 	}
 	return false
@@ -983,6 +988,47 @@ func (e *ReasoningEffort) UnmarshalGQL(v interface{}) error {
 }
 
 func (e ReasoningEffort) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type ReasoningMode string
+
+const (
+	ReasoningModeAdaptive ReasoningMode = "adaptive"
+	ReasoningModeBudget   ReasoningMode = "budget"
+)
+
+var AllReasoningMode = []ReasoningMode{
+	ReasoningModeAdaptive,
+	ReasoningModeBudget,
+}
+
+func (e ReasoningMode) IsValid() bool {
+	switch e {
+	case ReasoningModeAdaptive, ReasoningModeBudget:
+		return true
+	}
+	return false
+}
+
+func (e ReasoningMode) String() string {
+	return string(e)
+}
+
+func (e *ReasoningMode) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ReasoningMode(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ReasoningMode", str)
+	}
+	return nil
+}
+
+func (e ReasoningMode) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/backend/pkg/graph/schema.graphqls
+++ b/backend/pkg/graph/schema.graphqls
@@ -23,11 +23,19 @@ enum ProviderType {
   qwen
 }
 
-# Reasoning effort levels for advanced AI models (OpenAI format)
+# Reasoning effort levels for advanced AI models
 enum ReasoningEffort {
+  xhigh
+  max
   high
   medium
   low
+}
+
+# Reasoning control mode for provider-specific thinking APIs
+enum ReasoningMode {
+  adaptive
+  budget
 }
 
 # Template types for AI agent prompts and system operations
@@ -699,6 +707,7 @@ type ProviderConfig {
 
 # AI model reasoning configuration
 type ReasoningConfig {
+  mode: ReasoningMode
   effort: ReasoningEffort
   maxTokens: Int
 }
@@ -748,6 +757,7 @@ type AgentsConfig {
 
 # Input type for ReasoningConfig
 input ReasoningConfigInput {
+  mode: ReasoningMode
   effort: ReasoningEffort
   maxTokens: Int
 }

--- a/backend/pkg/providers/bedrock/adaptive_thinking.go
+++ b/backend/pkg/providers/bedrock/adaptive_thinking.go
@@ -1,0 +1,173 @@
+package bedrock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"pentagi/pkg/providers/pconfig"
+
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/vxcontrol/langchaingo/llms"
+)
+
+type adaptiveThinkingEffortContextKey struct{}
+
+func withAdaptiveThinkingEffort(ctx context.Context, effort string) context.Context {
+	if effort == "" {
+		effort = string(llms.ReasoningHigh)
+	}
+
+	return context.WithValue(ctx, adaptiveThinkingEffortContextKey{}, effort)
+}
+
+func adaptiveThinkingEffortFromContext(ctx context.Context) (string, bool) {
+	effort, ok := ctx.Value(adaptiveThinkingEffortContextKey{}).(string)
+	return effort, ok && effort != ""
+}
+
+func addAdaptiveThinkingMiddleware(stack *middleware.Stack) error {
+	return stack.Build.Add(middleware.BuildMiddlewareFunc(
+		"PentAGIBedrockAdaptiveThinking",
+		func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (
+			middleware.BuildOutput,
+			middleware.Metadata,
+			error,
+		) {
+			effort, ok := adaptiveThinkingEffortFromContext(ctx)
+			if !ok {
+				return next.HandleBuild(ctx, in)
+			}
+
+			req, ok := in.Request.(*smithyhttp.Request)
+			if !ok || req.GetStream() == nil {
+				return next.HandleBuild(ctx, in)
+			}
+
+			body, err := io.ReadAll(req.GetStream())
+			if err != nil {
+				return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("read Bedrock request body: %w", err)
+			}
+
+			updatedBody, err := rewriteAdaptiveThinkingBody(body, effort)
+			if err != nil {
+				return middleware.BuildOutput{}, middleware.Metadata{}, err
+			}
+
+			updatedReq, err := req.SetStream(bytes.NewReader(updatedBody))
+			if err != nil {
+				return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("replace Bedrock request body: %w", err)
+			}
+			updatedReq.ContentLength = int64(len(updatedBody))
+			updatedReq.Header.Set("Content-Length", strconv.Itoa(len(updatedBody)))
+			in.Request = updatedReq
+
+			return next.HandleBuild(ctx, in)
+		},
+	), middleware.After)
+}
+
+func rewriteAdaptiveThinkingBody(body []byte, effort string) ([]byte, error) {
+	// langchaingo currently emits budget-based Anthropic thinking for Bedrock;
+	// Claude adaptive thinking expects thinking.type=adaptive plus output_config.effort.
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode Bedrock request body: %w", err)
+	}
+
+	fields, ok := payload["additionalModelRequestFields"].(map[string]any)
+	if !ok {
+		return body, nil
+	}
+
+	thinking, ok := fields["thinking"].(map[string]any)
+	if !ok {
+		return body, nil
+	}
+
+	thinking["type"] = "adaptive"
+	delete(thinking, "budget_tokens")
+	fields["output_config"] = map[string]any{
+		"effort": effort,
+	}
+
+	updatedBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode Bedrock request body: %w", err)
+	}
+
+	return updatedBody, nil
+}
+
+func (p *bedrockProvider) prepareCallOptions(
+	ctx context.Context,
+	opt pconfig.ProviderOptionsType,
+	options []llms.CallOption,
+) (context.Context, []llms.CallOption) {
+	reasoning, ok := p.reasoningConfigForType(opt)
+	if !ok || reasoning.EffectiveMode() != pconfig.ReasoningModeAdaptive {
+		return ctx, options
+	}
+
+	effort := string(reasoning.Effort)
+	ctx = withAdaptiveThinkingEffort(ctx, effort)
+	options = append(options, llms.WithReasoning(llms.ReasoningHigh, 0))
+
+	return ctx, options
+}
+
+func (p *bedrockProvider) reasoningConfigForType(opt pconfig.ProviderOptionsType) (pconfig.ReasoningConfig, bool) {
+	agentConfig := p.agentConfigForType(opt)
+	if agentConfig == nil || agentConfig.Reasoning.IsZero() {
+		return pconfig.ReasoningConfig{}, false
+	}
+
+	return agentConfig.Reasoning, true
+}
+
+func (p *bedrockProvider) agentConfigForType(opt pconfig.ProviderOptionsType) *pconfig.AgentConfig {
+	if p == nil || p.providerConfig == nil {
+		return nil
+	}
+
+	switch opt {
+	case pconfig.OptionsTypeSimple:
+		return p.providerConfig.Simple
+	case pconfig.OptionsTypeSimpleJSON:
+		if p.providerConfig.SimpleJSON != nil {
+			return p.providerConfig.SimpleJSON
+		}
+		return p.providerConfig.Simple
+	case pconfig.OptionsTypePrimaryAgent:
+		return p.providerConfig.PrimaryAgent
+	case pconfig.OptionsTypeAssistant:
+		if p.providerConfig.Assistant != nil {
+			return p.providerConfig.Assistant
+		}
+		return p.providerConfig.PrimaryAgent
+	case pconfig.OptionsTypeGenerator:
+		return p.providerConfig.Generator
+	case pconfig.OptionsTypeRefiner:
+		return p.providerConfig.Refiner
+	case pconfig.OptionsTypeAdviser:
+		return p.providerConfig.Adviser
+	case pconfig.OptionsTypeReflector:
+		return p.providerConfig.Reflector
+	case pconfig.OptionsTypeSearcher:
+		return p.providerConfig.Searcher
+	case pconfig.OptionsTypeEnricher:
+		return p.providerConfig.Enricher
+	case pconfig.OptionsTypeCoder:
+		return p.providerConfig.Coder
+	case pconfig.OptionsTypeInstaller:
+		return p.providerConfig.Installer
+	case pconfig.OptionsTypePentester:
+		return p.providerConfig.Pentester
+	default:
+		return nil
+	}
+}

--- a/backend/pkg/providers/bedrock/adaptive_thinking_test.go
+++ b/backend/pkg/providers/bedrock/adaptive_thinking_test.go
@@ -1,0 +1,46 @@
+package bedrock
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteAdaptiveThinkingBody(t *testing.T) {
+	body := []byte(`{
+		"additionalModelRequestFields": {
+			"thinking": {
+				"type": "enabled",
+				"budget_tokens": 4096
+			}
+		},
+		"inferenceConfig": {
+			"maxTokens": 16384
+		}
+	}`)
+
+	updatedBody, err := rewriteAdaptiveThinkingBody(body, "xhigh")
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(updatedBody, &payload))
+
+	fields := payload["additionalModelRequestFields"].(map[string]any)
+	thinking := fields["thinking"].(map[string]any)
+	outputConfig := fields["output_config"].(map[string]any)
+
+	assert.Equal(t, "adaptive", thinking["type"])
+	assert.NotContains(t, thinking, "budget_tokens")
+	assert.Equal(t, "xhigh", outputConfig["effort"])
+	assert.Equal(t, map[string]any{"maxTokens": float64(16384)}, payload["inferenceConfig"])
+}
+
+func TestRewriteAdaptiveThinkingBodyWithoutThinking(t *testing.T) {
+	body := []byte(`{"inferenceConfig":{"maxTokens":1024}}`)
+
+	updatedBody, err := rewriteAdaptiveThinkingBody(body, "high")
+	require.NoError(t, err)
+	assert.JSONEq(t, string(body), string(updatedBody))
+}

--- a/backend/pkg/providers/bedrock/bedrock.go
+++ b/backend/pkg/providers/bedrock/bedrock.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	smithybearer "github.com/aws/smithy-go/auth/bearer"
+	"github.com/aws/smithy-go/middleware"
 	"github.com/invopop/jsonschema"
 	"github.com/vxcontrol/langchaingo/llms"
 	"github.com/vxcontrol/langchaingo/llms/bedrock"
@@ -84,6 +85,9 @@ func New(
 ) (provider.Provider, error) {
 	opts := []func(*bconfig.LoadOptions) error{
 		bconfig.WithRegion(cfg.BedrockRegion),
+		bconfig.WithAPIOptions([]func(*middleware.Stack) error{
+			addAdaptiveThinkingMiddleware,
+		}),
 	}
 
 	// Choose authentication strategy based on configuration
@@ -195,9 +199,10 @@ func (p *bedrockProvider) Call(
 	opt pconfig.ProviderOptionsType,
 	prompt string,
 ) (string, error) {
+	ctx, options := p.prepareCallOptions(ctx, opt, p.providerConfig.GetOptionsForType(opt))
+
 	return provider.WrapGenerateFromSinglePrompt(
-		ctx, p, opt, p.llm, prompt,
-		p.providerConfig.GetOptionsForType(opt)...,
+		ctx, p, opt, p.llm, prompt, options...,
 	)
 }
 
@@ -223,10 +228,11 @@ func (p *bedrockProvider) CallEx(
 	// Clean tools from $schema field
 	tools = cleanToolSchemas(tools)
 
-	// Build final options: streaming + config + cleaned tools LAST (to override any dirty tools from config)
+	// Put cleaned tools after config to override any dirty tools restored from config.
 	options := []llms.CallOption{llms.WithStreamingFunc(streamCb)}
 	options = append(options, configOptions...)
 	options = append(options, llms.WithTools(tools))
+	ctx, options = p.prepareCallOptions(ctx, opt, options)
 
 	return provider.WrapGenerateContent(ctx, p, opt, p.llm.GenerateContent, chain, options...)
 }
@@ -249,8 +255,9 @@ func (p *bedrockProvider) CallWithTools(
 
 	configOptions := p.providerConfig.GetOptionsForType(opt)
 
-	// Build final options: config + streaming + cleaned tools LAST (to override any dirty tools from config)
+	// Put cleaned tools after config to override any dirty tools restored from config.
 	options := append(configOptions, llms.WithStreamingFunc(streamCb), llms.WithTools(tools))
+	ctx, options = p.prepareCallOptions(ctx, opt, options)
 
 	return provider.WrapGenerateContent(ctx, p, opt, p.llm.GenerateContent, chain, options...)
 }

--- a/backend/pkg/providers/bedrock/config.yml
+++ b/backend/pkg/providers/bedrock/config.yml
@@ -83,7 +83,8 @@ adviser:
   n: 1
   max_tokens: 16384
   reasoning:
-    max_tokens: 4096
+    mode: adaptive
+    effort: high
   price:
     input: 5.0
     output: 25.0

--- a/backend/pkg/providers/bedrock/models.yml
+++ b/backend/pkg/providers/bedrock/models.yml
@@ -39,6 +39,17 @@
     input: 0.035
     output: 0.14
 
+# Anthropic Claude 4.7 Series - Latest Opus generation with adaptive thinking
+- name: us.anthropic.claude-opus-4-7
+  description: Most capable Opus model for advanced software engineering, long-running agentic tasks, professional work, and rigorous security analysis with adaptive thinking
+  thinking: true
+  release_date: 2026-04-16
+  price:
+    input: 5.0
+    output: 25.0
+    cache_read: 0.5
+    cache_write: 6.25
+
 # Anthropic Claude 4.6 Series - Latest generation with world-class coding and agentic capabilities
 - name: us.anthropic.claude-opus-4-6-v1
   description: World's best model for coding, enterprise agents, and professional work with industry-leading reliability for agentic workflows and security analysis

--- a/backend/pkg/providers/pconfig/config.go
+++ b/backend/pkg/providers/pconfig/config.go
@@ -185,9 +185,34 @@ type PriceInfo struct {
 	CacheWrite float64 `json:"cache_write,omitempty" yaml:"cache_write,omitempty"`
 }
 
+type ReasoningMode string
+
+const (
+	ReasoningModeDefault  ReasoningMode = ""
+	ReasoningModeAdaptive ReasoningMode = "adaptive"
+	ReasoningModeBudget   ReasoningMode = "budget"
+)
+
 type ReasoningConfig struct {
+	Mode      ReasoningMode        `json:"mode,omitempty" yaml:"mode,omitempty"`
 	Effort    llms.ReasoningEffort `json:"effort,omitempty" yaml:"effort,omitempty"`
 	MaxTokens int                  `json:"max_tokens,omitempty" yaml:"max_tokens,omitempty"`
+}
+
+func (rc ReasoningConfig) IsZero() bool {
+	return rc.Mode == ReasoningModeDefault &&
+		rc.Effort == llms.ReasoningNone &&
+		rc.MaxTokens == 0
+}
+
+func (rc ReasoningConfig) EffectiveMode() ReasoningMode {
+	if rc.Mode != ReasoningModeDefault {
+		return rc.Mode
+	}
+	if rc.MaxTokens != 0 && (rc.Effort == llms.ReasoningNone || rc.Effort == llms.ReasoningEffort("none")) {
+		return ReasoningModeBudget
+	}
+	return ReasoningModeDefault
 }
 
 // AgentConfig represents the configuration for a single agent
@@ -572,13 +597,24 @@ func (ac *AgentConfig) BuildOptions() []llms.CallOption {
 	if _, ok := ac.raw["response_mime_type"]; ok && ac.ResponseMIMEType != "" {
 		options = append(options, llms.WithResponseMIMEType(ac.ResponseMIMEType))
 	}
-	if _, ok := ac.raw["reasoning"]; ok && (ac.Reasoning.Effort != llms.ReasoningNone || ac.Reasoning.MaxTokens != 0) {
-		switch ac.Reasoning.Effort {
-		case llms.ReasoningLow, llms.ReasoningMedium, llms.ReasoningHigh:
-			options = append(options, llms.WithReasoning(ac.Reasoning.Effort, 0))
-		default:
+	if _, ok := ac.raw["reasoning"]; ok && !ac.Reasoning.IsZero() {
+		switch ac.Reasoning.EffectiveMode() {
+		case ReasoningModeAdaptive:
+			metadata := map[string]any{
+				"reasoning_mode": string(ReasoningModeAdaptive),
+			}
+			if ac.Reasoning.Effort != llms.ReasoningNone {
+				metadata["reasoning_effort"] = string(ac.Reasoning.Effort)
+			}
+			options = append(options, llms.WithMetadata(metadata))
+		case ReasoningModeBudget:
 			if ac.Reasoning.MaxTokens > 0 && ac.Reasoning.MaxTokens <= 32000 {
 				options = append(options, llms.WithReasoning(llms.ReasoningNone, ac.Reasoning.MaxTokens))
+			}
+		default:
+			switch ac.Reasoning.Effort {
+			case llms.ReasoningLow, llms.ReasoningMedium, llms.ReasoningHigh:
+				options = append(options, llms.WithReasoning(ac.Reasoning.Effort, 0))
 			}
 		}
 	}
@@ -643,7 +679,7 @@ func (ac *AgentConfig) marshalMap() map[string]any {
 	if ac.ResponseMIMEType != "" {
 		output["response_mime_type"] = ac.ResponseMIMEType
 	}
-	if ac.Reasoning.Effort != llms.ReasoningNone || ac.Reasoning.MaxTokens != 0 {
+	if !ac.Reasoning.IsZero() {
 		output["reasoning"] = ac.Reasoning
 	}
 	if ac.Price != nil {

--- a/backend/pkg/providers/pconfig/config_test.go
+++ b/backend/pkg/providers/pconfig/config_test.go
@@ -48,6 +48,14 @@ func TestReasoningConfig_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "with adaptive mode",
+			json: `{"mode": "adaptive", "effort": "xhigh"}`,
+			want: ReasoningConfig{
+				Mode:   ReasoningModeAdaptive,
+				Effort: llms.ReasoningEffort("xhigh"),
+			},
+		},
+		{
 			name:    "invalid json",
 			json:    "{invalid}",
 			wantErr: true,
@@ -65,6 +73,7 @@ func TestReasoningConfig_UnmarshalJSON(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			assert.Equal(t, tt.want.Mode, got.Mode)
 			assert.Equal(t, tt.want.Effort, got.Effort)
 			assert.Equal(t, tt.want.MaxTokens, got.MaxTokens)
 		})
@@ -109,6 +118,17 @@ max_tokens: 2000
 			},
 		},
 		{
+			name: "with adaptive mode",
+			yaml: `
+mode: adaptive
+effort: xhigh
+`,
+			want: ReasoningConfig{
+				Mode:   ReasoningModeAdaptive,
+				Effort: llms.ReasoningEffort("xhigh"),
+			},
+		},
+		{
 			name:    "invalid yaml",
 			yaml:    "invalid: [yaml",
 			wantErr: true,
@@ -126,6 +146,7 @@ max_tokens: 2000
 			}
 
 			require.NoError(t, err)
+			assert.Equal(t, tt.want.Mode, got.Mode)
 			assert.Equal(t, tt.want.Effort, got.Effort)
 			assert.Equal(t, tt.want.MaxTokens, got.MaxTokens)
 		})
@@ -922,6 +943,31 @@ func TestAgentConfig_BuildOptions(t *testing.T) {
 				}
 			}`,
 			wantLen: 3, // model, temperature, reasoning (max_tokens is set)
+		},
+		{
+			name:   "with adaptive reasoning mode",
+			format: "json",
+			config: `{
+				"model": "test-model",
+				"temperature": 0.7,
+				"reasoning": {
+					"mode": "adaptive",
+					"effort": "xhigh"
+				}
+			}`,
+			wantLen: 3, // model, temperature, metadata for adaptive reasoning
+			checkOptions: func(t *testing.T, options []llms.CallOption) {
+				var opts llms.CallOptions
+				for _, option := range options {
+					option(&opts)
+				}
+
+				assert.Equal(t, map[string]interface{}{
+					"reasoning_effort": "xhigh",
+					"reasoning_mode":   "adaptive",
+				}, opts.Metadata)
+				assert.Nil(t, opts.Reasoning)
+			},
 		},
 		{
 			name:   "with invalid reasoning tokens over limit",

--- a/frontend/graphql-schema.graphql
+++ b/frontend/graphql-schema.graphql
@@ -292,6 +292,7 @@ fragment agentConfigFragment on AgentConfig {
     frequencyPenalty
     presencePenalty
     reasoning {
+        mode
         effort
         maxTokens
     }

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -803,17 +803,26 @@ export type QueryVectorStoreLogsArgs = {
 export type ReasoningConfig = {
     effort?: Maybe<ReasoningEffort>;
     maxTokens?: Maybe<Scalars['Int']['output']>;
+    mode?: Maybe<ReasoningMode>;
 };
 
 export type ReasoningConfigInput = {
     effort?: InputMaybe<ReasoningEffort>;
     maxTokens?: InputMaybe<Scalars['Int']['input']>;
+    mode?: InputMaybe<ReasoningMode>;
 };
 
 export enum ReasoningEffort {
     High = 'high',
     Low = 'low',
+    Max = 'max',
     Medium = 'medium',
+    Xhigh = 'xhigh',
+}
+
+export enum ReasoningMode {
+    Adaptive = 'adaptive',
+    Budget = 'budget',
 }
 
 export enum ResultFormat {
@@ -1330,7 +1339,7 @@ export type AgentConfigFragmentFragment = {
     repetitionPenalty?: number | null;
     frequencyPenalty?: number | null;
     presencePenalty?: number | null;
-    reasoning?: { effort?: ReasoningEffort | null; maxTokens?: number | null } | null;
+    reasoning?: { mode?: ReasoningMode | null; effort?: ReasoningEffort | null; maxTokens?: number | null } | null;
     price?: { input: number; output: number; cacheRead: number; cacheWrite: number } | null;
 };
 
@@ -2301,6 +2310,7 @@ export const AgentConfigFragmentFragmentDoc = gql`
         frequencyPenalty
         presencePenalty
         reasoning {
+            mode
             effort
             maxTokens
         }

--- a/frontend/src/pages/settings/settings-provider.tsx
+++ b/frontend/src/pages/settings/settings-provider.tsx
@@ -14,7 +14,7 @@ import {
     XCircle,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useController, useForm, useFormState, useWatch } from 'react-hook-form';
+import { type Control, useController, useForm, type UseFormSetValue, useFormState, useWatch } from 'react-hook-form';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { z } from 'zod';
 
@@ -39,6 +39,7 @@ import { StatusCard } from '@/components/ui/status-card';
 import {
     AgentConfigType,
     ReasoningEffort,
+    ReasoningMode,
     useCreateProviderMutation,
     useDeleteProviderMutation,
     useSettingsProvidersQuery,
@@ -328,7 +329,9 @@ const FormModelComboboxItem: React.FC<FormModelComboboxItemProps> = ({
     const displayValue = field.value ?? '';
 
     // Format price for display
-    const formatPrice = (price?: null | { cacheRead: number; cacheWrite: number; input: number; output: number }): string => {
+    const formatPrice = (
+        price?: null | { cacheRead: number; cacheWrite: number; input: number; output: number },
+    ): string => {
         if (!price || ((!price.input || price.input === 0) && (!price.output || price.output === 0))) {
             return 'free';
         }
@@ -338,7 +341,7 @@ const FormModelComboboxItem: React.FC<FormModelComboboxItemProps> = ({
         };
 
         const basePrice = `$${formatValue(price.input)}/$${formatValue(price.output)}`;
-        
+
         // Add cache prices if available
         const hasCachePrices = (price.cacheRead && price.cacheRead > 0) || (price.cacheWrite && price.cacheWrite > 0);
 
@@ -519,6 +522,10 @@ const agentConfigSchema = z
                     (value) => (value === '' || value === undefined ? null : value),
                     z.number().nullable().optional(),
                 ),
+                mode: z.preprocess(
+                    (value) => (value === '' || value === undefined ? null : value),
+                    z.string().nullable().optional(),
+                ),
             })
             .nullable()
             .optional(),
@@ -559,6 +566,15 @@ type FormData = z.infer<typeof formSchema>;
 // Convert camelCase key to display name (e.g., 'simpleJson' -> 'Simple Json')
 const getName = (key: string): string => key.replaceAll(/([A-Z])/g, ' $1').replace(/^./, (item) => item.toUpperCase());
 
+const isBedrockAdaptiveThinkingModel = (model: string | undefined): boolean =>
+    !!model && /anthropic\.claude-(opus|sonnet)-4-[67]/.test(model);
+
+const getBedrockAdaptiveDefaultEffort = (model: string | undefined): ReasoningEffort =>
+    model?.includes('claude-opus-4-7') ? ReasoningEffort.Xhigh : ReasoningEffort.High;
+
+const isAdaptiveOnlyReasoningEffort = (effort: null | string | undefined): boolean =>
+    effort === ReasoningEffort.Xhigh || effort === ReasoningEffort.Max;
+
 // Helper function to convert string to ReasoningEffort enum
 const getReasoningEffort = (effort: null | string | undefined): null | ReasoningEffort => {
     if (!effort) {
@@ -574,8 +590,37 @@ const getReasoningEffort = (effort: null | string | undefined): null | Reasoning
             return ReasoningEffort.Low;
         }
 
+        case 'max': {
+            return ReasoningEffort.Max;
+        }
+
         case 'medium': {
             return ReasoningEffort.Medium;
+        }
+
+        case 'xhigh': {
+            return ReasoningEffort.Xhigh;
+        }
+
+        default: {
+            return null;
+        }
+    }
+};
+
+// Helper function to convert string to ReasoningMode enum
+const getReasoningMode = (mode: null | string | undefined): null | ReasoningMode => {
+    if (!mode) {
+        return null;
+    }
+
+    switch (mode.toLowerCase()) {
+        case 'adaptive': {
+            return ReasoningMode.Adaptive;
+        }
+
+        case 'budget': {
+            return ReasoningMode.Budget;
         }
 
         default: {
@@ -619,6 +664,7 @@ const transformFormToGraphQL = (
                     ? {
                           effort: getReasoningEffort(data?.reasoning.effort),
                           maxTokens: data?.reasoning.maxTokens ?? null,
+                          mode: getReasoningMode(data?.reasoning.mode),
                       }
                     : null,
                 repetitionPenalty: data?.repetitionPenalty ?? null,
@@ -635,6 +681,120 @@ const transformFormToGraphQL = (
         name: formData.name,
         type: formData.type as ProviderType,
     };
+};
+
+interface ReasoningConfigurationFieldsProps {
+    agentKey: string;
+    control: Control<FormData>;
+    disabled?: boolean;
+    setValue: UseFormSetValue<FormData>;
+}
+
+const ReasoningConfigurationFields: React.FC<ReasoningConfigurationFieldsProps> = ({
+    agentKey,
+    control,
+    disabled,
+    setValue,
+}) => {
+    const reasoningMode = useWatch({ control, name: `agents.${agentKey}.reasoning.mode` as const });
+    const reasoningEffort = useWatch({ control, name: `agents.${agentKey}.reasoning.effort` as const });
+    const isAdaptiveReasoning = reasoningMode === ReasoningMode.Adaptive;
+
+    return (
+        <div className="col-span-full p-px">
+            <div className="mt-6 flex flex-col gap-4">
+                <h4 className="text-sm font-medium">Reasoning Configuration</h4>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    {/* Reasoning Mode field */}
+                    <FormField
+                        control={control}
+                        name={`agents.${agentKey}.reasoning.mode` as const}
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Reasoning Mode</FormLabel>
+                                <Select
+                                    disabled={disabled}
+                                    onValueChange={(value) => {
+                                        const nextMode = value !== 'auto' ? value : null;
+
+                                        field.onChange(nextMode);
+
+                                        if (nextMode === ReasoningMode.Adaptive) {
+                                            setValue(`agents.${agentKey}.reasoning.maxTokens` as const, null);
+                                        } else if (isAdaptiveOnlyReasoningEffort(reasoningEffort)) {
+                                            setValue(`agents.${agentKey}.reasoning.effort` as const, null);
+                                        }
+                                    }}
+                                    value={field.value ?? 'auto'}
+                                >
+                                    <FormControl>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Select reasoning mode" />
+                                        </SelectTrigger>
+                                    </FormControl>
+                                    <SelectContent>
+                                        <SelectItem value="auto">Automatic</SelectItem>
+                                        <SelectItem value={ReasoningMode.Budget}>Token Budget</SelectItem>
+                                        <SelectItem value={ReasoningMode.Adaptive}>Adaptive</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <FormDescription>Use Adaptive for Claude Opus/Sonnet 4.6+ on Bedrock.</FormDescription>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    {/* Reasoning Effort field */}
+                    <FormField
+                        control={control}
+                        name={`agents.${agentKey}.reasoning.effort` as const}
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Reasoning Effort</FormLabel>
+                                <Select
+                                    disabled={disabled}
+                                    onValueChange={(value) => field.onChange(value !== 'none' ? value : null)}
+                                    value={field.value ?? 'none'}
+                                >
+                                    <FormControl>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Select effort level (optional)" />
+                                        </SelectTrigger>
+                                    </FormControl>
+                                    <SelectContent>
+                                        <SelectItem value="none">Not selected</SelectItem>
+                                        {isAdaptiveReasoning && (
+                                            <>
+                                                <SelectItem value={ReasoningEffort.Xhigh}>X-High</SelectItem>
+                                                <SelectItem value={ReasoningEffort.Max}>Max</SelectItem>
+                                            </>
+                                        )}
+                                        <SelectItem value={ReasoningEffort.Low}>Low</SelectItem>
+                                        <SelectItem value={ReasoningEffort.Medium}>Medium</SelectItem>
+                                        <SelectItem value={ReasoningEffort.High}>High</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    {/* Reasoning Max Tokens field */}
+                    {!isAdaptiveReasoning && (
+                        <FormInputNumberItem
+                            control={control}
+                            disabled={disabled}
+                            label="Reasoning Max Tokens"
+                            min="1"
+                            name={`agents.${agentKey}.reasoning.maxTokens`}
+                            placeholder="1000"
+                            valueType="integer"
+                        />
+                    )}
+                </div>
+            </div>
+        </div>
+    );
 };
 
 // Helper function to recursively remove __typename from objects
@@ -1526,6 +1686,21 @@ const SettingsProvider = () => {
                                                             `agents.${agentKey}.price.cacheWrite` as const,
                                                             price?.cacheWrite ?? null,
                                                         );
+
+                                                        if (isBedrockAdaptiveThinkingModel(option?.name)) {
+                                                            setValue(
+                                                                `agents.${agentKey}.reasoning.mode` as const,
+                                                                ReasoningMode.Adaptive,
+                                                            );
+                                                            setValue(
+                                                                `agents.${agentKey}.reasoning.effort` as const,
+                                                                getBedrockAdaptiveDefaultEffort(option?.name),
+                                                            );
+                                                            setValue(
+                                                                `agents.${agentKey}.reasoning.maxTokens` as const,
+                                                                null,
+                                                            );
+                                                        }
                                                     }}
                                                     options={availableModels}
                                                     placeholder="Select or enter model name"
@@ -1637,64 +1812,12 @@ const SettingsProvider = () => {
                                             </div>
 
                                             {/* Reasoning Configuration */}
-                                            <div className="col-span-full p-px">
-                                                <div className="mt-6 flex flex-col gap-4">
-                                                    <h4 className="text-sm font-medium">Reasoning Configuration</h4>
-                                                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                                                        {/* Reasoning Effort field */}
-                                                        <FormField
-                                                            control={control}
-                                                            name={`agents.${agentKey}.reasoning.effort`}
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>Reasoning Effort</FormLabel>
-                                                                    <Select
-                                                                        defaultValue={field.value ?? 'none'}
-                                                                        disabled={isLoading}
-                                                                        onValueChange={(value) =>
-                                                                            field.onChange(
-                                                                                value !== 'none' ? value : null,
-                                                                            )
-                                                                        }
-                                                                    >
-                                                                        <FormControl>
-                                                                            <SelectTrigger>
-                                                                                <SelectValue placeholder="Select effort level (optional)" />
-                                                                            </SelectTrigger>
-                                                                        </FormControl>
-                                                                        <SelectContent>
-                                                                            <SelectItem value="none">
-                                                                                Not selected
-                                                                            </SelectItem>
-                                                                            <SelectItem value={ReasoningEffort.Low}>
-                                                                                Low
-                                                                            </SelectItem>
-                                                                            <SelectItem value={ReasoningEffort.Medium}>
-                                                                                Medium
-                                                                            </SelectItem>
-                                                                            <SelectItem value={ReasoningEffort.High}>
-                                                                                High
-                                                                            </SelectItem>
-                                                                        </SelectContent>
-                                                                    </Select>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        {/* Reasoning Max Tokens field */}
-                                                        <FormInputNumberItem
-                                                            control={control}
-                                                            disabled={isLoading}
-                                                            label="Reasoning Max Tokens"
-                                                            min="1"
-                                                            name={`agents.${agentKey}.reasoning.maxTokens`}
-                                                            placeholder="1000"
-                                                            valueType="integer"
-                                                        />
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            <ReasoningConfigurationFields
+                                                agentKey={agentKey}
+                                                control={control}
+                                                disabled={isLoading}
+                                                setValue={setValue}
+                                            />
 
                                             {/* Price Configuration */}
                                             <div className="col-span-full p-px">


### PR DESCRIPTION
#### Problem
AWS Bedrock Claude Opus 4.7 rejects the current reasoning payload emitted by PentAGI/langchaingo:

thinking.type.enabled with budget_tokens

Bedrock returns a 400 validation error because Opus 4.7 requires adaptive thinking:

thinking.type.adaptive with output_config.effort

The settings UI also only exposed reasoning effort and max token budget, so users could not configure Bedrock adaptive
thinking from /settings/providers.
#### Solution
This PR introduces explicit reasoning modes to the provider configuration and settings UI. Here’s what’s included:

New ReasoningMode type: Supports adaptive and budget options, fully wired up across GraphQL, backend config, and frontend type generation.
Updated settings UI: Provider configs now include a Reasoning Mode dropdown with Automatic, Token Budget, and Adaptive options. The max tokens field automatically hides when Adaptive is selected since it’s not applicable.
Adaptive mode enhancements: Added xhigh and max reasoning effort levels. Adaptive mode will auto-select for Bedrock’s Claude Opus and Sonnet 4.6+ models, with Opus 4.7 defaulting to xhigh.
Bedrock middleware: Intercepts adaptive-thinking Converse requests and rewrites them to properly set thinking.type=adaptive and output_config.effort.
Model metadata & docs: Added Claude Opus 4.7 to Bedrock’s model metadata and updated the corresponding documentation.
Backward compatibility: Existing budget-based reasoning setups continue to work exactly as they do now, so there are no breaking changes.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### Type of Change
<!-- Mark with an `x` all options that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration change
- [ ] 🧪 Test update
- [ ] 🛡️ Security update

### Areas Affected
<!-- Mark with an `x` all components that are affected -->

- [x] Core Services (Frontend UI/Backend API)
- [x] AI Agents (Researcher/Developer/Executor)
- [ ] Security Tools Integration
- [ ] Memory System (Vector Store/Knowledge Base)
- [ ] Monitoring Stack (Grafana/OpenTelemetry)
- [ ] Analytics Platform (Langfuse)
- [ x] External Integrations (LLM/Search APIs)
- [ x] Documentation
- [ ] Infrastructure/DevOps

### Testing and Verification
<!--
Please describe the tests that you ran to verify your changes and provide instructions so we can reproduce.
-->

#### Test Configuration
```yaml
PentAGI Version: Latest Release (2.0)
Docker Version: Docker version 29.3.1, build c2be9cc
Host OS: Ubuntu 24.04.4 LTS on WSL2
LLM Provider: AWS Bedrock, Claude Opus 4.7
Enabled Features: Langfuse and Grafana
```

#### Test Steps
1. Built and ran a local PentAGI image.
2. Configured AWS Bedrock with us.anthropic.claude-opus-4-7.
3. Selected Reasoning Mode: Adaptive and a reasoning effort value in /settings/providers.
4. Ran provider/agent tests from the settings UI.
5. Verified the original Bedrock 400 validation error no longer occurs.
6. Ran focused backend, frontend, formatting, and lint validation. 

#### Test Results
Passed:
cd backend
go test ./pkg/providers/bedrock ./pkg/providers/pconfig ./pkg/database/converter ./pkg/graph
go vet ./pkg/providers/bedrock ./pkg/providers/pconfig ./pkg/database/converter ./pkg/graph

cd frontend
npm run build
npm run test
npx prettier --check src/pages/settings/settings-provider.tsx src/graphql/types.ts graphql-schema.graphql
npx eslint src/pages/settings/settings-provider.tsx

### Security Considerations
No new dependencies, credentials, permissions, or environment variables are introduced.

The Bedrock request rewrite only changes the serialized Converse request body for calls explicitly configured with
Adaptive reasoning mode. It does not log request bodies or expose provider secrets.

### Performance Impact
Runtime overhead is minimal: adaptive Bedrock calls perform one small JSON body rewrite before the AWS SDK sends the request.

Model-side performance may vary because adaptive thinking lets Claude choose reasoning depth based on task complexity.
This can change latency and output token usage compared with a fixed reasoning token budget.

### Documentation Updates
<!-- Note any documentation changes required by this PR -->

- [x] README.md updates
- [ ] API documentation updates
- [x] Configuration documentation updates
- [x] GraphQL schema updates
- [ ] Other: <!-- specify -->

### Deployment Notes
No migration or environment variable changes are required.
Existing provider configs remain backward compatible. Configs without reasoning.mode keep the previous behavior. For Claude Opus 4.7 on Bedrock, select Reasoning Mode: Adaptive and configure Reasoning Effort instead of Reasoning Max Tokens.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

#### Code Quality
- [x] My code follows the project's coding standards
- [x] I have added/updated necessary documentation
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] I have run `go fmt` and `go vet` (for Go code)
- [x] I have run `npm run lint` (for TypeScript/JavaScript code)

#### Security
- [x] I have considered security implications
- [x] Changes maintain or improve the security model
- [x] Sensitive information has been properly handled

#### Compatibility
- [x] Changes are backward compatible
- [x] Breaking changes are clearly marked and documented
- [x] Dependencies are properly updated

#### Documentation
- [x] Documentation is clear and complete
- [x] Comments are added for non-obvious code
- [x] API changes are documented

### Additional Notes
<!-- Any additional information that would be helpful for reviewers -->
