### PR TITLE
docs: explain assistant flow management for active flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,6 +1017,15 @@ Once the flow has enough results, use the **Report** menu on the flow page to:
 - download the report as Markdown
 - download the report as PDF
 
+### 4. Use the Assistant view to steer an active flow
+
+Each flow also includes an **Assistant** view for interactive guidance. This is useful when the autonomous run uncovers something that needs human direction instead of a hard restart.
+
+- Open the **Assistant** view for the same flow when you want to inspect the current state before changing anything.
+- Use the assistant to check flow status, stop the current task, submit follow-up instructions, or patch the remaining planned subtasks before the next step runs.
+- Treat this as an explicit control path for the current flow, not as an invisible background queue. If you want to change direction, say so clearly and keep the new instruction tied to the current engagement scope.
+- This works best for clarifying scope, redirecting priorities after intermediate findings, or answering an automation checkpoint without losing the rest of the flow context.
+
 For early testing, start with a narrow target and a single clear objective. This makes the output easier to review and helps you refine your prompts before running larger assessments.
 
 ## API Access


### PR DESCRIPTION
## Summary
- document how the Assistant view can manage an active flow without restarting the automation
- explain the explicit control path for checking status, stopping work, submitting follow-up input, and patching planned subtasks
- keep the guidance in the README first-use section where users are most likely to look for this workflow

## Problem
Issue #192 shows that users want a safe way to influence an in-progress automation. The implementation direction has shifted away from an in-memory queue and toward explicit assistant-side flow management tools, but that workflow is still hard to discover from the main README.

## Solution
Add a short user-facing section to the first-use guide that explains when to open the Assistant view for the same flow and what kinds of changes it is appropriate to make there.

## User Impact
Users get a clearer path for steering an active flow without assuming PentAGI uses a hidden background queue. This should reduce confusion around how to redirect or clarify an automation run after it has already started.

## Test Plan
- verify the new README section matches the current assistant flow-management behavior documented in `backend/docs/flow_execution.md`
- verify the wording does not promise hidden queueing or direct mid-command interruption
- `git diff --check`