### PR TITLE
docs: clarify web UI account setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,17 @@ docker compose up -d
 
 Visit [localhost:8443](https://localhost:8443) to access PentAGI Web UI (default is `admin@pentagi.com` / `admin`)
 
+#### Web UI Accounts
+
+PentAGI does not expose public self-service sign-up from the login page. A fresh installation creates the default local administrator account:
+
+- **Email**: `admin@pentagi.com`
+- **Password**: `admin`
+
+On first login, change the default password before using the instance for real work. If the administrator password is lost later, use the installer maintenance menu to reset the default `admin@pentagi.com` account password.
+
+For multi-user setups, an authenticated administrator can manage local users through the Users REST API (`/api/v1/users/`). The OpenAPI UI is available at `https://localhost:8443/api/v1/swagger/index.html` after the instance is running.
+
 > [!NOTE]
 > If you caught an error about `pentagi-network` or `observability-network` or `langfuse-network` you need to run `docker-compose.yml` firstly to create these networks and after that run `docker-compose-langfuse.yml`, `docker-compose-graphiti.yml`, and `docker-compose-observability.yml` to use Langfuse, Graphiti, and Observability services.
 >


### PR DESCRIPTION
Summary
- Adds a short Web UI Accounts section to the Quick Start flow.
- Clarifies that PentAGI does not provide public self-service sign-up from the login page.
- Documents the default local admin account, first-login password change expectation, installer reset path, and the authenticated Users REST API path for multi-user setups.

Problem
New users can see the Web UI login screen but the README only mentioned the default credentials in one line. That made it unclear whether they should sign up from the UI, use the seeded admin account, or manage additional users elsewhere.

Solution
I added a focused README note beside the Web UI access instructions, grounded in the current seeded admin account, password reset maintenance screen, and `/api/v1/users/` REST API.

User Impact
First-time operators get a clearer path into the UI and a more accurate expectation for multi-user setup without implying that public registration is available.

Test Plan
- Verified the default admin account against the initial database migration.
- Verified the installer has a reset-admin-password maintenance flow.
- Verified the Users REST API routes exist in the server router.
- Ran `git diff --check`.

Closes #289