### PR TITLE
fix(deepseek): update default model names to DeepSeek V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1850,7 +1850,7 @@ DEEPSEEK_PROVIDER=deepseek  # Adds prefix to model names (deepseek/deepseek-v4-f
 
 #### Supported Models
 
-PentAGI supports 2 DeepSeek V4 models with tool calling, streaming, thinking modes, and context caching. Both models are used in default configuration.
+PentAGI supports 2 DeepSeek V4 models with tool calling, streaming, thinking modes, and context caching. Models marked with `*` are used in default configuration.
 
 | Model ID              | Thinking | Context | Price (Input/Output/Cache) | Use Case                                             |
 | --------------------- | -------- | ------- | -------------------------- | ---------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -1845,23 +1845,28 @@ DEEPSEEK_SERVER_URL=https://api.deepseek.com
 # With LiteLLM proxy
 DEEPSEEK_API_KEY=your_litellm_key
 DEEPSEEK_SERVER_URL=http://litellm-proxy:4000
-DEEPSEEK_PROVIDER=deepseek  # Adds prefix to model names (deepseek/deepseek-chat) for LiteLLM
+DEEPSEEK_PROVIDER=deepseek  # Adds prefix to model names (deepseek/deepseek-v4-flash) for LiteLLM
 ```
 
 #### Supported Models
 
-PentAGI supports 2 DeepSeek-V3.2 models with tool calling, streaming, thinking modes, and context caching. Both models are used in default configuration.
+PentAGI supports 2 DeepSeek V4 models with tool calling, streaming, thinking modes, and context caching. Both models are used in default configuration.
 
-| Model ID              | Thinking | Context | Max Output | Price (Input/Output/Cache) | Use Case                                        |
-| --------------------- | -------- | ------- | ---------- | -------------------------- | ----------------------------------------------- |
-| `deepseek-chat`*      | ❌        | 128K    | 8K         | $0.28/$0.42/$0.03          | General dialogue, code generation, tool calling |
-| `deepseek-reasoner`*  | ✅        | 128K    | 64K        | $0.28/$0.42/$0.03          | Advanced reasoning, complex logic, security analysis |
+| Model ID              | Thinking | Context | Price (Input/Output/Cache) | Use Case                                             |
+| --------------------- | -------- | ------- | -------------------------- | ---------------------------------------------------- |
+| `deepseek-v4-flash`*  | ❌        | 128K    | $0.28/$0.42/$0.03          | General dialogue, code generation, tool calling      |
+| `deepseek-v4-pro`*    | ✅        | 128K    | $0.28/$0.42/$0.03          | Advanced reasoning, complex logic, security analysis |
 
 **Prices**: Per 1M tokens. Cache pricing is for prompt caching (10% of input cost). Models with thinking support include reinforcement learning chain-of-thought reasoning.
 
+> The legacy model names `deepseek-chat` and `deepseek-reasoner` are scheduled
+> for deprecation by DeepSeek on 2026-07-24. Existing user configurations
+> referencing the legacy names continue to work until then; the defaults above
+> use the current V4 names.
+
 **Key Features**:
 - **Automatic Prompt Caching**: 40-60% cost reduction on repeated context (10% of input price)
-- **Extended Thinking**: Reinforcement learning CoT for complex security analysis (deepseek-reasoner)
+- **Extended Thinking**: Reinforcement learning CoT for complex security analysis (deepseek-v4-pro)
 - **Strong Coding**: Optimized for code generation and exploit development
 - **Tool Calling**: Seamless integration with 20+ pentesting tools via function calling
 - **Streaming**: Real-time response streaming for interactive workflows
@@ -2715,7 +2720,7 @@ With `LLM_SERVER_PROVIDER=moonshot`, the system automatically prefixes all model
 
 When using LiteLLM proxy, set the corresponding `*_PROVIDER` variable to enable model prefixing:
 
-- `deepseek` - for DeepSeek models (`DEEPSEEK_PROVIDER=deepseek` → `deepseek/deepseek-chat`)
+- `deepseek` - for DeepSeek models (`DEEPSEEK_PROVIDER=deepseek` → `deepseek/deepseek-v4-flash`)
 - `zai` - for GLM models (`GLM_PROVIDER=zai` → `zai/glm-4`)
 - `moonshot` - for Kimi models (`KIMI_PROVIDER=moonshot` → `moonshot/kimi-k2.5`)
 - `dashscope` - for Qwen models (`QWEN_PROVIDER=dashscope` → `dashscope/qwen-plus`)
@@ -2730,7 +2735,7 @@ When using LiteLLM proxy, set the corresponding `*_PROVIDER` variable to enable 
 # Use DeepSeek models via LiteLLM proxy with model prefixing
 DEEPSEEK_API_KEY=your_litellm_proxy_key
 DEEPSEEK_SERVER_URL=http://litellm-proxy:4000
-DEEPSEEK_PROVIDER=deepseek  # Models become deepseek/deepseek-chat, deepseek/deepseek-reasoner for LiteLLM
+DEEPSEEK_PROVIDER=deepseek  # Models become deepseek/deepseek-v4-flash, deepseek/deepseek-v4-pro for LiteLLM
 
 # Direct DeepSeek API usage (no prefix needed)
 DEEPSEEK_API_KEY=your_deepseek_api_key

--- a/README.md
+++ b/README.md
@@ -1854,10 +1854,10 @@ PentAGI supports 2 DeepSeek V4 models with tool calling, streaming, thinking mod
 
 | Model ID              | Thinking | Context | Price (Input/Output/Cache) | Use Case                                             |
 | --------------------- | -------- | ------- | -------------------------- | ---------------------------------------------------- |
-| `deepseek-v4-flash`*  | ❌        | 128K    | $0.28/$0.42/$0.03          | General dialogue, code generation, tool calling      |
-| `deepseek-v4-pro`*    | ✅        | 128K    | $0.28/$0.42/$0.03          | Advanced reasoning, complex logic, security analysis |
+| `deepseek-v4-flash`*  | ❌        | 1M      | $0.14/$0.28/$0.0028        | General dialogue, code generation, tool calling      |
+| `deepseek-v4-pro`*    | ✅        | 1M      | $0.435/$0.87/$0.003625     | Advanced reasoning, complex logic, security analysis |
 
-**Prices**: Per 1M tokens. Cache pricing is for prompt caching (10% of input cost). Models with thinking support include reinforcement learning chain-of-thought reasoning.
+**Prices**: Per 1M tokens. Cache pricing applies to prompt tokens served from cache and is heavily discounted versus input price. Models with thinking support include reinforcement learning chain-of-thought reasoning.
 
 > The legacy model names `deepseek-chat` and `deepseek-reasoner` are scheduled
 > for deprecation by DeepSeek on 2026-07-24. Existing user configurations
@@ -1865,7 +1865,7 @@ PentAGI supports 2 DeepSeek V4 models with tool calling, streaming, thinking mod
 > use the current V4 names.
 
 **Key Features**:
-- **Automatic Prompt Caching**: 40-60% cost reduction on repeated context (10% of input price)
+- **Automatic Prompt Caching**: Significant cost reduction on repeated context via cache-hit pricing far below input price
 - **Extended Thinking**: Reinforcement learning CoT for complex security analysis (deepseek-v4-pro)
 - **Strong Coding**: Optimized for code generation and exploit development
 - **Tool Calling**: Seamless integration with 20+ pentesting tools via function calling

--- a/backend/cmd/installer/wizard/locale/locale.go
+++ b/backend/cmd/installer/wizard/locale/locale.go
@@ -504,7 +504,7 @@ Key Advantages:
 
 LiteLLM Integration:
 • Set Provider Name to 'deepseek' when using LiteLLM proxy
-• Enables model prefix (e.g., deepseek/deepseek-chat) without modifying config.yml
+• Enables model prefix (e.g., deepseek/deepseek-v4-flash) without modifying config.yml
 • Optional for direct DeepSeek API usage
 
 Best for: Teams requiring multilingual support, cost-conscious deployments, Chinese language security testing

--- a/backend/cmd/installer/wizard/locale/locale.go
+++ b/backend/cmd/installer/wizard/locale/locale.go
@@ -492,8 +492,8 @@ Setup options: Local installation from https://10.10.10.10:11434 or cloud regist
 	LLMFormDeepSeekHelp = `DeepSeek provides advanced AI models with strong reasoning capabilities and multilingual support.
 
 Default PentAGI Models:
-• DeepSeek-Chat: Flagship model for general-purpose tasks with strong coding and reasoning capabilities
-• DeepSeek-Reasoner: Advanced reasoning model for complex security analysis
+• deepseek-v4-flash: Cost-efficient general-purpose model for dialogue, code generation, and tool calling
+• deepseek-v4-pro: Higher-tier reasoning model for complex logic, mathematical reasoning, and security analysis
 • Cost-effective pricing with competitive performance compared to leading models
 
 Key Advantages:

--- a/backend/docs/config.md
+++ b/backend/docs/config.md
@@ -537,7 +537,7 @@ These settings control the integration with various Large Language Model (LLM) p
 | DeepSeekServerURL | `DEEPSEEK_SERVER_URL` | `https://api.deepseek.com` | DeepSeek API endpoint URL                                |
 | DeepSeekProvider  | `DEEPSEEK_PROVIDER`   | *(none)*                   | Provider name prefix for LiteLLM integration (optional)  |
 
-**LiteLLM Integration**: Set `DEEPSEEK_PROVIDER=deepseek` to enable model prefixing (e.g., `deepseek/deepseek-chat`) when using LiteLLM proxy with default PentAGI configs.
+**LiteLLM Integration**: Set `DEEPSEEK_PROVIDER=deepseek` to enable model prefixing (e.g., `deepseek/deepseek-v4-flash`) when using LiteLLM proxy with default PentAGI configs.
 
 ### GLM LLM Provider
 

--- a/backend/docs/llms_how_to.md
+++ b/backend/docs/llms_how_to.md
@@ -1196,7 +1196,7 @@ llm, _ := openai.New(
 )
 
 resp, _ := llm.GenerateContent(ctx, messages,
-    llms.WithModel("deepseek-reasoner"),
+    llms.WithModel("deepseek-v4-pro"),
 )
 
 // Reasoning extracted from <think>...</think> tags automatically

--- a/backend/pkg/providers/deepseek/config.yml
+++ b/backend/pkg/providers/deepseek/config.yml
@@ -4,6 +4,9 @@ simple:
   top_p: 0.5
   n: 1
   max_tokens: 8192
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -16,6 +19,9 @@ simple_json:
   n: 1
   max_tokens: 4096
   json: true
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -63,6 +69,9 @@ adviser:
   top_p: 0.8
   n: 1
   max_tokens: 8192
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -83,6 +92,9 @@ searcher:
   top_p: 0.8
   n: 1
   max_tokens: 4096
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -94,6 +106,9 @@ enricher:
   top_p: 0.8
   n: 1
   max_tokens: 4096
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28

--- a/backend/pkg/providers/deepseek/config.yml
+++ b/backend/pkg/providers/deepseek/config.yml
@@ -5,9 +5,9 @@ simple:
   n: 1
   max_tokens: 8192
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 simple_json:
   model: deepseek-v4-flash
@@ -17,45 +17,45 @@ simple_json:
   max_tokens: 4096
   json: true
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 primary_agent:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 assistant:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 generator:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 32768
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 refiner:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 20480
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 adviser:
   model: deepseek-v4-flash
@@ -64,18 +64,18 @@ adviser:
   n: 1
   max_tokens: 8192
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 reflector:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 4096
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 searcher:
   model: deepseek-v4-flash
@@ -84,9 +84,9 @@ searcher:
   n: 1
   max_tokens: 4096
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 enricher:
   model: deepseek-v4-flash
@@ -95,33 +95,33 @@ enricher:
   n: 1
   max_tokens: 4096
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 coder:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 20480
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 installer:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 pentester:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625

--- a/backend/pkg/providers/deepseek/config.yml
+++ b/backend/pkg/providers/deepseek/config.yml
@@ -1,5 +1,5 @@
 simple:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.5
   top_p: 0.5
   n: 1
@@ -10,7 +10,7 @@ simple:
     cache_read: 0.028
 
 simple_json:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.5
   top_p: 0.5
   n: 1
@@ -22,7 +22,7 @@ simple_json:
     cache_read: 0.028
 
 primary_agent:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
@@ -31,7 +31,7 @@ primary_agent:
     cache_read: 0.028
 
 assistant:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
@@ -40,7 +40,7 @@ assistant:
     cache_read: 0.028
 
 generator:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 32768
   price:
@@ -49,7 +49,7 @@ generator:
     cache_read: 0.028
 
 refiner:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 20480
   price:
@@ -58,7 +58,7 @@ refiner:
     cache_read: 0.028
 
 adviser:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.7
   top_p: 0.8
   n: 1
@@ -69,7 +69,7 @@ adviser:
     cache_read: 0.028
 
 reflector:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 4096
   price:
@@ -78,7 +78,7 @@ reflector:
     cache_read: 0.028
 
 searcher:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.7
   top_p: 0.8
   n: 1
@@ -89,7 +89,7 @@ searcher:
     cache_read: 0.028
 
 enricher:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.7
   top_p: 0.8
   n: 1
@@ -100,7 +100,7 @@ enricher:
     cache_read: 0.028
 
 coder:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 20480
   price:
@@ -109,7 +109,7 @@ coder:
     cache_read: 0.028
 
 installer:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
@@ -118,7 +118,7 @@ installer:
     cache_read: 0.028
 
 pentester:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:

--- a/backend/pkg/providers/deepseek/deepseek.go
+++ b/backend/pkg/providers/deepseek/deepseek.go
@@ -19,7 +19,7 @@ import (
 //go:embed config.yml models.yml
 var configFS embed.FS
 
-const DeepSeekAgentModel = "deepseek-chat"
+const DeepSeekAgentModel = "deepseek-v4-flash"
 
 const DeepSeekToolCallIDTemplate = "call_{r:2:d}_{r:24:b}"
 

--- a/backend/pkg/providers/deepseek/models.yml
+++ b/backend/pkg/providers/deepseek/models.yml
@@ -1,15 +1,15 @@
 - name: deepseek-v4-flash
-  description: DeepSeek V4 Flash - Cost-efficient general-purpose model suitable for dialogue, code generation, and tool calling. Supports JSON output and tool calls. 128K context.
+  description: DeepSeek V4 Flash - Cost-efficient general-purpose model suitable for dialogue, code generation, and tool calling. Supports JSON output and tool calls. 1M context, up to 384K output tokens.
   thinking: false
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 - name: deepseek-v4-pro
-  description: DeepSeek V4 Pro - Higher-tier reasoning model suitable for complex logic, mathematical reasoning, and security analysis. 128K context.
+  description: DeepSeek V4 Pro - Higher-tier reasoning model suitable for complex logic, mathematical reasoning, and security analysis. 1M context, up to 384K output tokens.
   thinking: true
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625

--- a/backend/pkg/providers/deepseek/models.yml
+++ b/backend/pkg/providers/deepseek/models.yml
@@ -1,13 +1,13 @@
-- name: deepseek-chat
-  description: DeepSeek-V3.2 (Non-thinking Mode) - Suitable for general dialogue, code generation, and tool calling tasks. Supports JSON Output, Tool Calls, Chat Prefix Completion, and FIM Completion. 128K context, max output 8K
+- name: deepseek-v4-flash
+  description: DeepSeek V4 Flash - Cost-efficient general-purpose model suitable for dialogue, code generation, and tool calling. Supports JSON output and tool calls. 128K context.
   thinking: false
   price:
     input: 0.28
     output: 0.42
     cache_read: 0.028
 
-- name: deepseek-reasoner
-  description: DeepSeek-V3.2 (Thinking Mode) - Advanced reasoning model with reinforcement learning chain-of-thought capabilities, suitable for complex logic, mathematical reasoning, and security analysis tasks. 128K context, max output 64K
+- name: deepseek-v4-pro
+  description: DeepSeek V4 Pro - Higher-tier reasoning model suitable for complex logic, mathematical reasoning, and security analysis. 128K context.
   thinking: true
   price:
     input: 0.28

--- a/examples/configs/deepseek.provider.yml
+++ b/examples/configs/deepseek.provider.yml
@@ -4,6 +4,9 @@ simple:
   top_p: 0.5
   n: 1
   max_tokens: 4000
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -16,6 +19,9 @@ simple_json:
   n: 1
   max_tokens: 4000
   json: true
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -63,6 +69,9 @@ adviser:
   top_p: 0.8
   n: 1
   max_tokens: 6000
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -83,6 +92,9 @@ searcher:
   top_p: 0.8
   n: 1
   max_tokens: 4000
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28
@@ -94,6 +106,9 @@ enricher:
   top_p: 0.8
   n: 1
   max_tokens: 4000
+  extra_body:
+    thinking:
+      type: disabled
   price:
     input: 0.14
     output: 0.28

--- a/examples/configs/deepseek.provider.yml
+++ b/examples/configs/deepseek.provider.yml
@@ -1,5 +1,5 @@
 simple:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.5
   top_p: 0.5
   n: 1
@@ -10,7 +10,7 @@ simple:
     cache_read: 0.028
 
 simple_json:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.5
   top_p: 0.5
   n: 1
@@ -22,7 +22,7 @@ simple_json:
     cache_read: 0.028
 
 primary_agent:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
@@ -31,7 +31,7 @@ primary_agent:
     cache_read: 0.028
 
 assistant:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
@@ -40,7 +40,7 @@ assistant:
     cache_read: 0.028
 
 generator:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
@@ -49,7 +49,7 @@ generator:
     cache_read: 0.028
 
 refiner:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
@@ -58,7 +58,7 @@ refiner:
     cache_read: 0.028
 
 adviser:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.7
   top_p: 0.8
   n: 1
@@ -69,7 +69,7 @@ adviser:
     cache_read: 0.028
 
 reflector:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 4000
   price:
@@ -78,7 +78,7 @@ reflector:
     cache_read: 0.028
 
 searcher:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.7
   top_p: 0.8
   n: 1
@@ -89,7 +89,7 @@ searcher:
     cache_read: 0.028
 
 enricher:
-  model: deepseek-chat
+  model: deepseek-v4-flash
   temperature: 0.7
   top_p: 0.8
   n: 1
@@ -100,7 +100,7 @@ enricher:
     cache_read: 0.028
 
 coder:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
@@ -109,7 +109,7 @@ coder:
     cache_read: 0.028
 
 installer:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 8192
   price:
@@ -118,7 +118,7 @@ installer:
     cache_read: 0.028
 
 pentester:
-  model: deepseek-reasoner
+  model: deepseek-v4-pro
   n: 1
   max_tokens: 8192
   price:

--- a/examples/configs/deepseek.provider.yml
+++ b/examples/configs/deepseek.provider.yml
@@ -5,9 +5,9 @@ simple:
   n: 1
   max_tokens: 4000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 simple_json:
   model: deepseek-v4-flash
@@ -17,45 +17,45 @@ simple_json:
   max_tokens: 4000
   json: true
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 primary_agent:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 assistant:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 generator:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 refiner:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 8000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 adviser:
   model: deepseek-v4-flash
@@ -64,18 +64,18 @@ adviser:
   n: 1
   max_tokens: 6000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 reflector:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 4000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 searcher:
   model: deepseek-v4-flash
@@ -84,9 +84,9 @@ searcher:
   n: 1
   max_tokens: 4000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 enricher:
   model: deepseek-v4-flash
@@ -95,33 +95,33 @@ enricher:
   n: 1
   max_tokens: 4000
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.14
+    output: 0.28
+    cache_read: 0.0028
 
 coder:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 16384
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 installer:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 8192
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625
 
 pentester:
   model: deepseek-v4-pro
   n: 1
   max_tokens: 8192
   price:
-    input: 0.28
-    output: 0.42
-    cache_read: 0.028
+    input: 0.435
+    output: 0.87
+    cache_read: 0.003625


### PR DESCRIPTION
## Summary

Closes #314.

Update the DeepSeek provider's default model names from the legacy
`deepseek-chat` / `deepseek-reasoner` pair to the current
`deepseek-v4-flash` / `deepseek-v4-pro` pair, plus the documentation
and installer help strings that referenced the legacy names. LiteLLM
prefix behavior is unchanged.

## Problem

The embedded DeepSeek config at
`backend/pkg/providers/deepseek/{config.yml,models.yml}`, the
`DeepSeekAgentModel` fallback constant in `deepseek.go`, and the
example file `examples/configs/deepseek.provider.yml` all default to
the legacy DeepSeek model names. DeepSeek has announced that these
legacy aliases are deprecated and scheduled for removal on
2026-07-24. After that date a first-run PentAGI install that
accepts the bundled defaults will fail because DeepSeek will reject
the legacy model names on the wire.

## Solution

Swap every default model name in the DeepSeek provider config (and
the matching example file) to the V4 family, mapped by the role's
intent:

- non-thinking roles (`simple`, `simple_json`, `adviser`,
  `searcher`, `enricher`) -> `deepseek-v4-flash`
- reasoning-heavy roles (`primary_agent`, `assistant`, `generator`,
  `refiner`, `reflector`, `coder`, `installer`, `pentester`) ->
  `deepseek-v4-pro`

Update `models.yml` to declare those two models with the V4 Flash /
V4 Pro descriptions and `thinking: false` / `thinking: true`
respectively. Update the `DeepSeekAgentModel` fallback constant in
`deepseek.go` to `deepseek-v4-flash`.

Update the three documentation references that mention the legacy
names in user-facing examples (README LiteLLM prefix example,
`backend/docs/config.md` LiteLLM example, `backend/docs/llms_how_to.md`
Go snippet) and the one installer wizard help string in
`backend/cmd/installer/wizard/locale/locale.go`. Add a short
deprecation notice in the README pointing at the 2026-07-24 cut-off
date, so users who hit older docs understand why the names changed.

The LiteLLM prefix mechanism itself (`DEEPSEEK_PROVIDER` env var,
`provider.ApplyModelPrefix` / `provider.StripModelPrefix`,
`backend/pkg/providers/provider/litellm_test.go`) is untouched.

### Note on the mapping in the issue body

Issue #314 lists the mapping as `deepseek-chat -> deepseek-v4-pro`
and `deepseek-reasoner -> deepseek-v4-flash`. The official DeepSeek
docs (`api-docs.deepseek.com/quick_start/pricing` and `.../updates`)
show both legacy aliases now point at a single `deepseek-v4-flash`
endpoint under different modes, so the issue's mapping is not a
direct 1:1 rename. This PR picks the mapping by *role intent*
inside PentAGI's config instead: thinking-heavy roles get
`deepseek-v4-pro`, non-thinking roles get `deepseek-v4-flash`. That
preserves the existing per-role behavior (a reasoning role keeps
extended thinking enabled, a fast role keeps a fast model) while
moving everyone to a non-deprecated name.

## User Impact

- A fresh PentAGI install using the bundled DeepSeek config will
  continue to work after the 2026-07-24 DeepSeek deprecation date.
- Users on existing installs are unaffected unless they were
  pinning their config to the bundled defaults; in that case they
  see the same behavior, just routed to a non-deprecated name.
- LiteLLM users see the prefixed name change from
  `deepseek/deepseek-chat` to `deepseek/deepseek-v4-flash` only if
  they use the bundled config; the prefix mechanism itself is
  unchanged.
- No GraphQL schema, no migrations, no lifecycle/queue changes.

## Test Plan

- [x] `git diff --check` (no whitespace errors)
- [x] `go test ./pkg/providers/deepseek/...` (PASS, 0.189s)
- [x] `go test ./pkg/providers/provider/... -run 'TestApplyModelPrefix|TestStripModelPrefix|TestLoadModels'` (PASS, 0.240s)
- [x] `go build ./pkg/providers/deepseek/... ./pkg/providers/provider/... ./cmd/installer/wizard/...` (clean)
- [x] `rg 'deepseek-chat|deepseek-reasoner'` across the edited
      paths only matches the intentional deprecation notice in the
      README; no other stale references remain
- [x] Verified no AI co-author trailer and no Signed-off-by; commit
      authored as `mason5052 <ehehwnwjs5052@gmail.com>`