### PR TITLE
docs(llm): clarify Vertex AI configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,16 @@ ANTHROPIC_API_KEY=your_anthropic_api_key
 PROXY_URL=http://your-proxy:8080
 ```
 
+> [!NOTE]
+> **Google Vertex AI for Claude models**
+>
+> PentAGI does not currently expose a dedicated Google Vertex AI configuration path for Anthropic Claude in `.env`. There is no separate Vertex AI API key field at this time, and the existing Anthropic variables (`ANTHROPIC_API_KEY`, `ANTHROPIC_SERVER_URL`) target the direct Anthropic API. Supported routes for Claude are:
+>
+> - **Direct Anthropic API**: `ANTHROPIC_API_KEY` and `ANTHROPIC_SERVER_URL` (see above).
+> - **AWS Bedrock**: `BEDROCK_*` variables (see [AWS Bedrock Provider Configuration](#aws-bedrock-provider-configuration)).
+>
+> If you need to use Vertex AI today, the safest supported workaround is to expose Vertex AI through an OpenAI-compatible proxy or gateway that translates Vertex AI calls into the Chat Completions format while preserving the chat and tool-call behavior PentAGI relies on, then point the Custom LLM provider at that gateway via `LLM_SERVER_URL`, `LLM_SERVER_KEY`, and `LLM_SERVER_MODEL`. This path is only as reliable as the gateway you choose.
+
 #### Supported Models
 
 PentAGI supports 10 Claude models with tool calling, streaming, extended thinking, adaptive thinking, and prompt caching. Models marked with `*` are used in default configuration.

--- a/backend/docs/config.md
+++ b/backend/docs/config.md
@@ -490,6 +490,13 @@ These settings control the integration with various Large Language Model (LLM) p
 | AnthropicAPIKey    | `ANTHROPIC_API_KEY`    | *(none)*                       | API key for Anthropic Claude services |
 | AnthropicServerURL | `ANTHROPIC_SERVER_URL` | `https://api.anthropic.com/v1` | Server URL for Anthropic API requests |
 
+**Note on Google Vertex AI**: PentAGI does not currently expose a dedicated Vertex AI configuration path for Anthropic Claude in `.env`. The variables above target the direct Anthropic API. To run Claude through a non-Anthropic-hosted backend, use one of:
+
+- **AWS Bedrock**: see the [AWS Bedrock LLM Provider](#aws-bedrock-llm-provider) section below and configure the `BEDROCK_*` variables.
+- **OpenAI-compatible gateway in front of Vertex AI**: expose Vertex AI through a proxy or gateway that translates requests into the Chat Completions format while preserving the chat and tool-call behavior PentAGI requires, then configure it as a [custom LLM provider](#custom-llm-provider) (`LLM_SERVER_URL`, `LLM_SERVER_KEY`, `LLM_SERVER_MODEL`). Reliability of this path depends on the gateway you choose.
+
+There is no `VERTEX_API_KEY` or `GOOGLE_APPLICATION_CREDENTIALS` variable wired into PentAGI's provider initialization today.
+
 ### Ollama LLM Provider
 
 | Option                        | Environment Variable                | Default Value        | Description                                                       |


### PR DESCRIPTION
## Summary

Clarify in the user-facing LLM provider docs that PentAGI does not currently expose a dedicated Google Vertex AI configuration path for Anthropic Claude in `.env`, and describe the routes that actually work today (direct Anthropic, AWS Bedrock, or a custom OpenAI-compatible gateway).

Docs-only change. No Go code, no installer behavior, no new environment variables.

## Problem

Issue #310 asks how to provide a Google Vertex AI API key in `.env` for Anthropic Claude. PentAGI's `.env.example`, `backend/pkg/config`, and `backend/cmd/installer/wizard` do not read any `VERTEX_*`, `GOOGLE_APPLICATION_CREDENTIALS`, or `vertex_ai` variable. The current provider initialization for Claude only knows about:

- `ANTHROPIC_API_KEY` / `ANTHROPIC_SERVER_URL` (direct Anthropic API)
- `BEDROCK_REGION` / `BEDROCK_DEFAULT_AUTH` / `BEDROCK_BEARER_TOKEN` / `BEDROCK_ACCESS_KEY_ID` / `BEDROCK_SECRET_ACCESS_KEY` / `BEDROCK_SESSION_TOKEN` / `BEDROCK_SERVER_URL` (AWS Bedrock)
- `LLM_SERVER_URL` / `LLM_SERVER_KEY` / `LLM_SERVER_MODEL` (custom OpenAI-compatible endpoint)

Today this leaves users guessing whether some hidden Vertex AI configuration exists. The user in issue #310 hit exactly this — they "tried multiple methods of adding Anthropic's Claude models Vertex AI keys but the application couldn't parse it."

## Solution

Add a small clarification in two places, matching the existing style of each file:

- `README.md`: a `> [!NOTE]` callout inside the Anthropic Provider Configuration section. It states the current limitation, lists the supported Claude routes (direct Anthropic, AWS Bedrock), and describes the safest workaround for users who must use Vertex AI today (front it with an OpenAI-compatible gateway and configure the existing Custom LLM provider, with a caveat that reliability depends on the gateway).
- `backend/docs/config.md`: a matching Note paragraph under the Anthropic section, pointing at the AWS Bedrock LLM Provider and Custom LLM Provider sections already in the same doc, and stating that no `VERTEX_API_KEY` or `GOOGLE_APPLICATION_CREDENTIALS` variable is wired into provider initialization today.

Wording is intentionally hedged ("currently", "at this time", "today") to avoid permanent claims, and no fake env vars are introduced.

## User Impact

- Users following issue #310 get a direct, accurate answer in the docs they were already reading.
- New users evaluating PentAGI for Claude-on-Vertex-AI workloads see the limitation up front and the supported workaround, instead of trial-and-erroring `.env` keys that do nothing.
- No runtime change: existing deployments keep working unchanged.

## Test Plan

- [x] `git diff --check` clean
- [x] `git status` shows only `README.md` and `backend/docs/config.md` modified; no unrelated dirty files staged
- [x] Verified every env var named in the new text exists in code or existing docs:
  - `ANTHROPIC_API_KEY`, `ANTHROPIC_SERVER_URL`: `backend/pkg/config/config.go`, `.env.example`, README, `backend/docs/config.md`
  - `BEDROCK_REGION`, `BEDROCK_DEFAULT_AUTH`, `BEDROCK_BEARER_TOKEN`, `BEDROCK_ACCESS_KEY_ID`, `BEDROCK_SECRET_ACCESS_KEY`, `BEDROCK_SESSION_TOKEN`, `BEDROCK_SERVER_URL`: `backend/pkg/config/config.go`, `.env.example`, README, `backend/docs/config.md`
  - `LLM_SERVER_URL`, `LLM_SERVER_KEY`, `LLM_SERVER_MODEL`: `backend/pkg/config/config.go`, `.env.example`, `backend/docs/config.md`
- [x] Verified `VERTEX_*`, `vertex_ai`, and `GOOGLE_APPLICATION_CREDENTIALS` are NOT present in `backend/pkg/config` or `backend/pkg/providers` — the doc claim that no such variable is wired in today is accurate
- [x] Anchor links resolve: `#aws-bedrock-provider-configuration` (README) and `#aws-bedrock-llm-provider` + `#custom-llm-provider` (config.md) match real headings in the same files
- [x] No runtime Go files, installer behavior, or generated files modified

Refs #310