### PR TITLE
fix(providers): clarify misleading docker image LLM error (#312)

### DIFF
--- a/backend/pkg/providers/providers.go
+++ b/backend/pkg/providers/providers.go
@@ -410,7 +410,7 @@ func (pc *providerController) NewFlowProvider(
 
 	image, err := prv.Call(ctx, pconfig.OptionsTypeSimple, imageTmpl)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get primary docker image: %w", err)
+		return nil, fmt.Errorf("failed to select primary docker image via llm call: %w", err)
 	}
 	image = strings.ToLower(strings.TrimSpace(image))
 


### PR DESCRIPTION
## Fixes
Fixes #312

## Problem
On a fresh setup, creating any flow fails with:

```
failed to get flow provider: failed to get primary docker image: API returned unexpected status code: 404
```

Because the message says **"primary docker image"**, users (and several issues — #312, #309, and #203) spend time debugging Docker, image pulls, and the registry. The actual failure is unrelated to Docker.

## Root Cause
In `NewFlowProvider` (`backend/pkg/providers/providers.go`), the **first** LLM call during flow creation asks the configured provider to *select* a primary Docker image:

```go
image, err := prv.Call(ctx, pconfig.OptionsTypeSimple, imageTmpl)
if err != nil {
    return nil, fmt.Errorf("failed to get primary docker image: %w", err)
}
```

When the configured LLM backend is unsupported or misconfigured, `prv.Call` returns the provider's HTTP `404`. The error is wrapped with wording that points at Docker rather than the LLM provider, so the underlying `404` looks like a Docker registry error. As maintainers have noted on #312/#309, the 404 originates from the LLM backend.

## Solution
Reword the wrapped error so the failing component (the LLM call) is identified, while still naming the image-selection step:

```
failed to select primary docker image via llm call: API returned unexpected status code: 404
```

One-line message change; no behavioral change.

## Testing
```
cd backend && go build ./pkg/providers/
# -> builds OK
```

## Risk Assessment
Minimal. Only the text of a wrapped error string changes; no control flow, signatures, or behavior are affected. The substring `primary docker image` is retained, so any log scraping keyed on that phrase keeps matching.
