### PR TITLE
fix(installer): propagate swallowed GatherUpdatesInfo errors

### DIFF
--- a/backend/cmd/installer/processor/logic.go
+++ b/backend/cmd/installer/processor/logic.go
@@ -149,8 +149,8 @@ func (p *processor) applyChanges(ctx context.Context, state *operationState) (er
 			return
 		}
 		// refresh state for updates
-		if err := p.checker.GatherUpdatesInfo(ctx); err != nil {
-			err = fmt.Errorf("failed to gather info after update: %w", err)
+		if gatherErr := p.checker.GatherUpdatesInfo(ctx); gatherErr != nil {
+			err = fmt.Errorf("failed to gather info after update: %w", gatherErr)
 		}
 	}()
 
@@ -446,8 +446,8 @@ func (p *processor) install(ctx context.Context, state *operationState) (err err
 			return
 		}
 		// refresh state for updates
-		if err := p.checker.GatherUpdatesInfo(ctx); err != nil {
-			err = fmt.Errorf("failed to gather info after update: %w", err)
+		if gatherErr := p.checker.GatherUpdatesInfo(ctx); gatherErr != nil {
+			err = fmt.Errorf("failed to gather info after update: %w", gatherErr)
 		}
 	}()
 
@@ -499,8 +499,8 @@ func (p *processor) update(ctx context.Context, stack ProductStack, state *opera
 			return
 		}
 		// refresh state for updates
-		if err := p.checker.GatherUpdatesInfo(ctx); err != nil {
-			err = fmt.Errorf("failed to gather info after update: %w", err)
+		if gatherErr := p.checker.GatherUpdatesInfo(ctx); gatherErr != nil {
+			err = fmt.Errorf("failed to gather info after update: %w", gatherErr)
 		}
 	}()
 
@@ -694,7 +694,7 @@ func (p *processor) remove(ctx context.Context, stack ProductStack, state *opera
 			return fmt.Errorf("failed to gather worker info after remove: %w", err)
 		}
 		if err := p.checker.GatherUpdatesInfo(ctx); err != nil {
-			err = fmt.Errorf("failed to gather info after update: %w", err)
+			return fmt.Errorf("failed to gather info after update: %w", err)
 		}
 
 	case ProductStackInstaller:
@@ -733,8 +733,8 @@ func (p *processor) purge(ctx context.Context, stack ProductStack, state *operat
 			return
 		}
 		// refresh state for updates
-		if err := p.checker.GatherUpdatesInfo(ctx); err != nil {
-			err = fmt.Errorf("failed to gather info after update: %w", err)
+		if gatherErr := p.checker.GatherUpdatesInfo(ctx); gatherErr != nil {
+			err = fmt.Errorf("failed to gather info after update: %w", gatherErr)
 		}
 	}()
 
@@ -774,7 +774,7 @@ func (p *processor) purge(ctx context.Context, stack ProductStack, state *operat
 			return fmt.Errorf("failed to gather worker info after purge: %w", err)
 		}
 		if err := p.checker.GatherUpdatesInfo(ctx); err != nil {
-			err = fmt.Errorf("failed to gather info after update: %w", err)
+			return fmt.Errorf("failed to gather info after update: %w", err)
 		}
 
 	case ProductStackInstaller:


### PR DESCRIPTION
## Problem
In the installer processor (`cmd/installer/processor/logic.go`), failures from the post-operation state refresh `checker.GatherUpdatesInfo(ctx)` were silently discarded. As a result `apply` / `install` / `update` / `remove` / `purge` could report **success** to the UI even when the post-step refresh actually failed.

Surfaced by `golangci-lint` (`ineffassign`), which the project's CI runs with `--issues-exit-code=0`, so these never blocked anything.

## Root Cause
Two distinct patterns wrapped the error into a value that was then thrown away:

1. **Deferred closures** in `applyChanges`, `install`, `update`, `purge`:
   ```go
   defer func() {
       if err != nil { return }
       if err := p.checker.GatherUpdatesInfo(ctx); err != nil { // shadows named return
           err = fmt.Errorf("failed to gather info after update: %w", err) // assigns the shadow
       }
   }()
   ```
   The inner `if err := ...` shadows the function's named return `err`, so the wrap never reaches the outer `defer sendCompletion(stack, err)`.

2. **`ProductStackWorker` switch cases** in `remove` and `purge`:
   ```go
   if err := p.checker.GatherUpdatesInfo(ctx); err != nil {
       err = fmt.Errorf("failed to gather info after update: %w", err) // block-local, falls through
   }
   ```
   The block-local `err` is wrapped but the case falls through without returning — even though every sibling check in the same switch `return`s on error.

## Solution
- **Deferred closures:** wrap into a `gatherErr` local and assign the named return `err`, so the failure propagates to `sendCompletion`.
- **Switch cases:** `return` the wrapped error, matching the sibling checks in the same `switch`.

The two contexts need different fixes: a deferred closure cannot `return` the operation's error, so it must assign the named return; the switch cases follow the established early-return-on-error contract.

## Testing
```
go build ./cmd/installer/...           # OK
go vet ./cmd/installer/processor/...    # OK
go test ./cmd/installer/processor/...   # ok
golangci-lint run -E ineffassign ./cmd/installer/processor/...   # logic.go clean
```

## Risk Assessment
Low. Behavior changes only on the previously-swallowed error path:
- Deferred-closure cases now report a `GatherUpdatesInfo` failure that was previously hidden (no early return added — semantics of the success path unchanged).
- The two switch cases now early-return on `GatherUpdatesInfo` error, consistent with every adjacent check in the same switch. The success path (err == nil) is unchanged.
No public API, schema, or migration changes.
