### PR TITLE
docs: clarify "primary docker image" error is an LLM backend failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2683,7 +2683,7 @@ To diagnose:
 1. Check PentAGI logs first: `docker logs pentagi`.
 2. Check the logs of your configured LLM backend (the server behind your provider or `LLM_SERVER_URL`).
 3. Verify that the base URL, API key, and model name in [Custom LLM Provider Configuration](#custom-llm-provider-configuration) are correct and reachable from the container.
-4. For custom, OpenAI-compatible, vLLM, or sglang backends, confirm that the model supports tool calling / function calling and that the matching tool-call parser is enabled. A missing or mismatched tool-call parser is a known cause of this failure.
+4. For custom, OpenAI-compatible, vLLM, or SGLang backends, confirm that the model supports tool calling (function calling) and that the matching tool-call parser is enabled. A missing or mismatched tool-call parser is a known cause of this failure.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -2674,7 +2674,7 @@ See the official Docker documentation for [registry mirrors](https://docs.docker
 
 A flow that fails immediately with `failed to select primary docker image via llm call` usually indicates a problem with the configured LLM backend, not with Docker or the image registry. Older PentAGI versions reported the same failure as `failed to get primary docker image`, which led users to debug Docker even though the registry was healthy.
 
-When a flow starts, PentAGI makes its first LLM call to choose the primary Docker image for the task. If that call fails, the error is surfaced at this image-selection step. A message such as `API returned unexpected status code: 502` or `404` in this context is returned by the LLM backend, not by Docker Hub.
+When a flow starts, PentAGI makes its first LLM call to choose the primary Docker image for the task. This image-selection call runs through the `simple` agent type, so a failure here points at the model assigned to that agent type rather than at Docker. A message such as `API returned unexpected status code: 502` or `404` in this context is returned by the LLM backend, not by Docker Hub.
 
 This is distinct from the registry reachability problems described above: if Docker pulls succeed and the Compose stack starts, but flow creation still fails at image selection, investigate the LLM backend rather than Docker.
 
@@ -2682,7 +2682,7 @@ To diagnose:
 
 1. Check PentAGI logs first: `docker logs pentagi`.
 2. Check the logs of your configured LLM backend (the server behind your provider or `LLM_SERVER_URL`).
-3. Verify that the base URL, API key, and model name in [Custom LLM Provider Configuration](#custom-llm-provider-configuration) are correct and reachable from the container.
+3. Verify that the base URL, API key, and model name in [Custom LLM Provider Configuration](#custom-llm-provider-configuration) are correct and reachable from the container. If you assign different models per agent type, check the model used by the `simple` agent type, since image selection runs through it.
 4. For custom, OpenAI-compatible, vLLM, or SGLang backends, confirm that the model supports tool calling (function calling) and that the matching tool-call parser is enabled. A missing or mismatched tool-call parser is a known cause of this failure.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -2670,6 +2670,21 @@ On Linux, this is typically configured in `/etc/docker/daemon.json`. On Docker D
 
 See the official Docker documentation for [registry mirrors](https://docs.docker.com/docker-hub/image-library/mirror/) and [daemon proxy configuration](https://docs.docker.com/engine/daemon/proxy/).
 
+#### Troubleshooting: "failed to select primary docker image via llm call"
+
+A flow that fails immediately with `failed to select primary docker image via llm call` usually indicates a problem with the configured LLM backend, not with Docker or the image registry. Older PentAGI versions reported the same failure as `failed to get primary docker image`, which led users to debug Docker even though the registry was healthy.
+
+When a flow starts, PentAGI makes its first LLM call to choose the primary Docker image for the task. If that call fails, the error is surfaced at this image-selection step. A message such as `API returned unexpected status code: 502` or `404` in this context is returned by the LLM backend, not by Docker Hub.
+
+This is distinct from the registry reachability problems described above: if Docker pulls succeed and the Compose stack starts, but flow creation still fails at image selection, investigate the LLM backend rather than Docker.
+
+To diagnose:
+
+1. Check PentAGI logs first: `docker logs pentagi`.
+2. Check the logs of your configured LLM backend (the server behind your provider or `LLM_SERVER_URL`).
+3. Verify that the base URL, API key, and model name in [Custom LLM Provider Configuration](#custom-llm-provider-configuration) are correct and reachable from the container.
+4. For custom, OpenAI-compatible, vLLM, or sglang backends, confirm that the model supports tool calling / function calling and that the matching tool-call parser is enabled. A missing or mismatched tool-call parser is a known cause of this failure.
+
 ## Development
 
 ### Development Requirements


### PR DESCRIPTION
## Summary

Add a troubleshooting subsection to the README "Docker Image Configuration" section clarifying that the `failed to select primary docker image via llm call` error (older versions: `failed to get primary docker image`) is an LLM backend failure during image selection, not a Docker or registry problem.

Refs #309

## Problem

On a fresh install, creating a flow can fail immediately with:

```
failed to get flow provider: failed to select primary docker image via llm call: API returned unexpected status code: 502
```

The phrase "primary docker image" leads users to debug Docker, the image registry, or pull access even though Docker is healthy. As the maintainer noted on #309 (and on the related #312 and #203), the real cause is the configured LLM backend: PentAGI makes its first LLM call to choose the primary image when a flow starts, so a backend failure (502/404, unreachable endpoint, wrong model, or a missing/mismatched tool-call parser on custom/sglang-style backends) surfaces at this step.

The error string itself was already made more precise in #312 / #320 (`failed to get primary docker image` -> `failed to select primary docker image via llm call`). This PR closes the remaining documentation gap so users can act on that clarified message.

## Solution

Add a short `#### Troubleshooting` subsection under "Docker Image Configuration" that:

- States the error indicates an LLM backend problem, not Docker or the registry.
- Explains the image-selection-at-flow-start mechanism so the origin of a 502/404 is clear.
- Distinguishes it from the existing "Restricted Networks, Docker Mirrors, and Proxies" subsection, which covers genuine registry reachability.
- Gives concrete diagnosis steps: check `docker logs pentagi`, check the LLM backend logs, verify the provider URL/key/model, and confirm tool-call / function-calling parser support for custom, OpenAI-compatible, vLLM, or sglang backends.
- Cross-links to the existing "Custom LLM Provider Configuration" section.

Documentation only. No runtime, schema, config, or behavior changes.

## User Impact

Users who hit this error can immediately look in the right place (the LLM backend) instead of debugging Docker, reducing time-to-resolution for a recurring fresh-install confusion reported across #309, #312, and #203.

## Test Plan

- Documentation-only change; no Go or frontend code touched.
- `git diff --check` reports no whitespace errors.
- Verified only `README.md` is modified (15 insertions).
- Verified the cross-link anchor `#custom-llm-provider-configuration` resolves to the existing "Custom LLM Provider Configuration" heading.
- Reviewed the rendered Markdown for correct heading, list, and code-span formatting.
