### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -135,6 +135,11 @@ type Config struct {
 	QwenServerURL string `env:"QWEN_SERVER_URL" envDefault:"https://dashscope-us.aliyuncs.com/compatible-mode/v1"`
 	QwenProvider  string `env:"QWEN_PROVIDER"`
 
+	// === LLM Provider: MiniMax ===
+	MiniMaxAPIKey    string `env:"MINIMAX_API_KEY"`
+	MiniMaxServerURL string `env:"MINIMAX_SERVER_URL" envDefault:"https://api.minimax.io/v1"`
+	MiniMaxProvider  string `env:"MINIMAX_PROVIDER"`
+
 	// === Search Engine: DuckDuckGo ===
 	DuckDuckGoEnabled    bool   `env:"DUCKDUCKGO_ENABLED" envDefault:"true"`
 	DuckDuckGoRegion     string `env:"DUCKDUCKGO_REGION"`
@@ -322,6 +327,7 @@ func (c *Config) GetSecretPatterns() []patterns.Pattern {
 		{c.GLMAPIKey, "GLM Key"},
 		{c.KimiAPIKey, "Kimi Key"},
 		{c.QwenAPIKey, "Qwen Key"},
+		{c.MiniMaxAPIKey, "MiniMax Key"},
 		{c.GoogleAPIKey, "Google API Key"},
 		{c.GoogleCXKey, "Google CX Key"},
 		{c.OAuthGoogleClientID, "Google Client ID"},

--- a/backend/pkg/providers/minimax/config.yml
+++ b/backend/pkg/providers/minimax/config.yml
@@ -1,0 +1,130 @@
+simple:
+  model: MiniMax-M3
+  temperature: 0.5
+  top_p: 0.5
+  n: 1
+  max_tokens: 8192
+  price:
+    input: 0.60
+    output: 2.40
+
+simple_json:
+  model: MiniMax-M3
+  temperature: 0.5
+  top_p: 0.5
+  n: 1
+  max_tokens: 4096
+  json: true
+  price:
+    input: 0.60
+    output: 2.40
+
+primary_agent:
+  model: MiniMax-M3
+  temperature: 0.7
+  top_p: 0.8
+  n: 1
+  max_tokens: 16384
+  price:
+    input: 0.60
+    output: 2.40
+
+assistant:
+  model: MiniMax-M3
+  temperature: 0.7
+  top_p: 0.8
+  n: 1
+  max_tokens: 16384
+  price:
+    input: 0.60
+    output: 2.40
+
+generator:
+  model: MiniMax-M3
+  temperature: 0.7
+  top_p: 0.8
+  n: 1
+  max_tokens: 32768
+  price:
+    input: 0.60
+    output: 2.40
+
+refiner:
+  model: MiniMax-M3
+  temperature: 0.7
+  top_p: 0.8
+  n: 1
+  max_tokens: 20480
+  price:
+    input: 0.60
+    output: 2.40
+
+adviser:
+  model: MiniMax-M3
+  temperature: 0.7
+  top_p: 0.8
+  n: 1
+  max_tokens: 8192
+  price:
+    input: 0.60
+    output: 2.40
+
+reflector:
+  model: MiniMax-M3
+  temperature: 0.5
+  top_p: 0.5
+  n: 1
+  max_tokens: 4096
+  price:
+    input: 0.60
+    output: 2.40
+
+searcher:
+  model: MiniMax-M3
+  temperature: 0.7
+  top_p: 0.8
+  n: 1
+  max_tokens: 4096
+  price:
+    input: 0.60
+    output: 2.40
+
+enricher:
+  model: MiniMax-M3
+  temperature: 0.7
+  top_p: 0.8
+  n: 1
+  max_tokens: 4096
+  price:
+    input: 0.60
+    output: 2.40
+
+coder:
+  model: MiniMax-M3
+  temperature: 0.5
+  top_p: 0.5
+  n: 1
+  max_tokens: 20480
+  price:
+    input: 0.60
+    output: 2.40
+
+installer:
+  model: MiniMax-M3
+  temperature: 0.5
+  top_p: 0.5
+  n: 1
+  max_tokens: 16384
+  price:
+    input: 0.60
+    output: 2.40
+
+pentester:
+  model: MiniMax-M3
+  temperature: 0.5
+  top_p: 0.5
+  n: 1
+  max_tokens: 16384
+  price:
+    input: 0.60
+    output: 2.40

--- a/backend/pkg/providers/minimax/minimax.go
+++ b/backend/pkg/providers/minimax/minimax.go
@@ -1,0 +1,194 @@
+package minimax
+
+import (
+	"context"
+	"embed"
+	"fmt"
+
+	"pentagi/pkg/config"
+	"pentagi/pkg/providers/pconfig"
+	"pentagi/pkg/providers/provider"
+	"pentagi/pkg/system"
+	"pentagi/pkg/templates"
+
+	"github.com/vxcontrol/langchaingo/llms"
+	"github.com/vxcontrol/langchaingo/llms/openai"
+	"github.com/vxcontrol/langchaingo/llms/streaming"
+)
+
+//go:embed config.yml models.yml
+var configFS embed.FS
+
+// MiniMaxAgentModel is the fallback model used when no agent-specific configuration exists.
+// MiniMax-M3 is the latest flagship model (512K context, up to 128K output, image input support)
+// and serves as the default for all agent types.
+const MiniMaxAgentModel = "MiniMax-M3"
+
+// MiniMaxToolCallIDTemplate is the pattern template for tool call IDs used by MiniMax.
+const MiniMaxToolCallIDTemplate = "call_{r:24:b}"
+
+func BuildProviderConfig(configData []byte) (*pconfig.ProviderConfig, error) {
+	defaultOptions := []llms.CallOption{
+		llms.WithModel(MiniMaxAgentModel),
+		llms.WithN(1),
+		llms.WithMaxTokens(4000),
+	}
+
+	providerConfig, err := pconfig.LoadConfigData(configData, defaultOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return providerConfig, nil
+}
+
+func DefaultProviderConfig() (*pconfig.ProviderConfig, error) {
+	configData, err := configFS.ReadFile("config.yml")
+	if err != nil {
+		return nil, err
+	}
+
+	return BuildProviderConfig(configData)
+}
+
+func DefaultModels() (pconfig.ModelsConfig, error) {
+	configData, err := configFS.ReadFile("models.yml")
+	if err != nil {
+		return nil, err
+	}
+
+	return pconfig.LoadModelsConfigData(configData)
+}
+
+type minimaxProvider struct {
+	llm            *openai.LLM
+	models         pconfig.ModelsConfig
+	providerName   provider.ProviderName
+	providerConfig *pconfig.ProviderConfig
+	providerPrefix string
+}
+
+func New(
+	cfg *config.Config,
+	providerName provider.ProviderName,
+	providerConfig *pconfig.ProviderConfig,
+) (provider.Provider, error) {
+	if cfg.MiniMaxAPIKey == "" {
+		return nil, fmt.Errorf("missing MINIMAX_API_KEY environment variable")
+	}
+
+	httpClient, err := system.GetHTTPClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := DefaultModels()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openai.New(
+		openai.WithToken(cfg.MiniMaxAPIKey),
+		openai.WithModel(MiniMaxAgentModel),
+		openai.WithBaseURL(cfg.MiniMaxServerURL),
+		openai.WithHTTPClient(httpClient),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &minimaxProvider{
+		llm:            client,
+		models:         models,
+		providerName:   providerName,
+		providerConfig: providerConfig,
+		providerPrefix: cfg.MiniMaxProvider,
+	}, nil
+}
+
+func (p *minimaxProvider) Type() provider.ProviderType {
+	return provider.ProviderMiniMax
+}
+
+func (p *minimaxProvider) Name() provider.ProviderName {
+	return p.providerName
+}
+
+func (p *minimaxProvider) GetRawConfig() []byte {
+	return p.providerConfig.GetRawConfig()
+}
+
+func (p *minimaxProvider) GetProviderConfig() *pconfig.ProviderConfig {
+	return p.providerConfig
+}
+
+func (p *minimaxProvider) GetPriceInfo(opt pconfig.ProviderOptionsType) *pconfig.PriceInfo {
+	return p.providerConfig.GetPriceInfoForType(opt)
+}
+
+func (p *minimaxProvider) GetModels() pconfig.ModelsConfig {
+	return p.models
+}
+
+func (p *minimaxProvider) Model(opt pconfig.ProviderOptionsType) string {
+	model := MiniMaxAgentModel
+	opts := llms.CallOptions{Model: &model}
+	for _, option := range p.providerConfig.GetOptionsForType(opt) {
+		option(&opts)
+	}
+
+	return opts.GetModel()
+}
+
+func (p *minimaxProvider) ModelWithPrefix(opt pconfig.ProviderOptionsType) string {
+	return provider.ApplyModelPrefix(p.Model(opt), p.providerPrefix)
+}
+
+func (p *minimaxProvider) Call(
+	ctx context.Context,
+	opt pconfig.ProviderOptionsType,
+	prompt string,
+) (string, error) {
+	return provider.WrapGenerateFromSinglePrompt(
+		ctx, p, opt, p.llm, prompt,
+		p.providerConfig.GetOptionsForType(opt)...,
+	)
+}
+
+func (p *minimaxProvider) CallEx(
+	ctx context.Context,
+	opt pconfig.ProviderOptionsType,
+	chain []llms.MessageContent,
+	streamCb streaming.Callback,
+) (*llms.ContentResponse, error) {
+	return provider.WrapGenerateContent(
+		ctx, p, opt, p.llm.GenerateContent, chain,
+		append([]llms.CallOption{
+			llms.WithStreamingFunc(streamCb),
+		}, p.providerConfig.GetOptionsForType(opt)...)...,
+	)
+}
+
+func (p *minimaxProvider) CallWithTools(
+	ctx context.Context,
+	opt pconfig.ProviderOptionsType,
+	chain []llms.MessageContent,
+	tools []llms.Tool,
+	streamCb streaming.Callback,
+) (*llms.ContentResponse, error) {
+	return provider.WrapGenerateContent(
+		ctx, p, opt, p.llm.GenerateContent, chain,
+		append([]llms.CallOption{
+			llms.WithTools(tools),
+			llms.WithStreamingFunc(streamCb),
+		}, p.providerConfig.GetOptionsForType(opt)...)...,
+	)
+}
+
+func (p *minimaxProvider) GetUsage(info map[string]any) pconfig.CallUsage {
+	return pconfig.NewCallUsage(info)
+}
+
+func (p *minimaxProvider) GetToolCallIDTemplate(ctx context.Context, prompter templates.Prompter) (string, error) {
+	return provider.DetermineToolCallIDTemplate(ctx, p, pconfig.OptionsTypeSimple, prompter, MiniMaxToolCallIDTemplate)
+}

--- a/backend/pkg/providers/minimax/minimax_test.go
+++ b/backend/pkg/providers/minimax/minimax_test.go
@@ -1,0 +1,229 @@
+package minimax
+
+import (
+	"testing"
+
+	"pentagi/pkg/config"
+	"pentagi/pkg/providers/pconfig"
+	"pentagi/pkg/providers/provider"
+)
+
+func TestConfigLoading(t *testing.T) {
+	cfg := &config.Config{
+		MiniMaxAPIKey:    "test-key",
+		MiniMaxServerURL: "https://api.minimax.io/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, provider.DefaultProviderNameMiniMax, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	rawConfig := prov.GetRawConfig()
+	if len(rawConfig) == 0 {
+		t.Fatal("Raw config should not be empty")
+	}
+
+	providerConfig = prov.GetProviderConfig()
+	if providerConfig == nil {
+		t.Fatal("Provider config should not be nil")
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		model := prov.Model(agentType)
+		if model == "" {
+			t.Errorf("Agent type %v should have a model assigned", agentType)
+		}
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		priceInfo := prov.GetPriceInfo(agentType)
+		if priceInfo == nil {
+			t.Errorf("Agent type %v should have price information", agentType)
+		} else {
+			if priceInfo.Input <= 0 || priceInfo.Output <= 0 {
+				t.Errorf("Agent type %v should have positive input (%f) and output (%f) prices",
+					agentType, priceInfo.Input, priceInfo.Output)
+			}
+		}
+	}
+}
+
+func TestProviderType(t *testing.T) {
+	cfg := &config.Config{
+		MiniMaxAPIKey:    "test-key",
+		MiniMaxServerURL: "https://api.minimax.io/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, provider.DefaultProviderNameMiniMax, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	if prov.Type() != provider.ProviderMiniMax {
+		t.Errorf("Expected provider type %v, got %v", provider.ProviderMiniMax, prov.Type())
+	}
+}
+
+func TestModelsLoading(t *testing.T) {
+	models, err := DefaultModels()
+	if err != nil {
+		t.Fatalf("Failed to load models: %v", err)
+	}
+
+	if len(models) == 0 {
+		t.Fatal("Models list should not be empty")
+	}
+
+	wantModels := map[string]bool{
+		"MiniMax-M3":             false,
+		"MiniMax-M2.7":           false,
+		"MiniMax-M2.7-highspeed": false,
+	}
+
+	for _, model := range models {
+		if model.Name == "" {
+			t.Error("Model name should not be empty")
+		}
+
+		if model.Price == nil {
+			t.Errorf("Model %s should have price information", model.Name)
+			continue
+		}
+
+		if model.Price.Input <= 0 {
+			t.Errorf("Model %s should have positive input price", model.Name)
+		}
+
+		if model.Price.Output <= 0 {
+			t.Errorf("Model %s should have positive output price", model.Name)
+		}
+
+		if _, ok := wantModels[model.Name]; ok {
+			wantModels[model.Name] = true
+		}
+	}
+
+	for name, found := range wantModels {
+		if !found {
+			t.Errorf("Expected model %q in models list, but it was not found", name)
+		}
+	}
+
+	if models[0].Name != "MiniMax-M3" {
+		t.Errorf("Expected first model to be MiniMax-M3 (default), got %q", models[0].Name)
+	}
+
+	for _, model := range models {
+		if model.Name == "MiniMax-M2.5" || model.Name == "MiniMax-M2.5-highspeed" ||
+			model.Name == "MiniMax-M2.1" || model.Name == "MiniMax-M2" || model.Name == "MiniMax-M1" {
+			t.Errorf("Legacy model %q should not be in the model list", model.Name)
+		}
+	}
+}
+
+func TestModelWithPrefix(t *testing.T) {
+	cfg := &config.Config{
+		MiniMaxAPIKey:    "test-key",
+		MiniMaxServerURL: "https://api.minimax.io/v1",
+		MiniMaxProvider:  "minimax",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, provider.DefaultProviderNameMiniMax, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		expected := "minimax/" + model
+		if modelWithPrefix != expected {
+			t.Errorf("Agent type %v: expected prefixed model %q, got %q", agentType, expected, modelWithPrefix)
+		}
+	}
+}
+
+func TestModelWithoutPrefix(t *testing.T) {
+	cfg := &config.Config{
+		MiniMaxAPIKey:    "test-key",
+		MiniMaxServerURL: "https://api.minimax.io/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, provider.DefaultProviderNameMiniMax, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	for _, agentType := range pconfig.AllAgentTypes {
+		modelWithPrefix := prov.ModelWithPrefix(agentType)
+		model := prov.Model(agentType)
+
+		if modelWithPrefix != model {
+			t.Errorf("Agent type %v: without prefix, ModelWithPrefix (%q) should equal Model (%q)",
+				agentType, modelWithPrefix, model)
+		}
+	}
+}
+
+func TestMissingAPIKey(t *testing.T) {
+	cfg := &config.Config{
+		MiniMaxServerURL: "https://api.minimax.io/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	_, err = New(cfg, provider.DefaultProviderNameMiniMax, providerConfig)
+	if err == nil {
+		t.Fatal("Expected error when API key is missing")
+	}
+}
+
+func TestGetUsage(t *testing.T) {
+	cfg := &config.Config{
+		MiniMaxAPIKey:    "test-key",
+		MiniMaxServerURL: "https://api.minimax.io/v1",
+	}
+
+	providerConfig, err := DefaultProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to create provider config: %v", err)
+	}
+
+	prov, err := New(cfg, provider.DefaultProviderNameMiniMax, providerConfig)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	usage := prov.GetUsage(map[string]any{
+		"PromptTokens":     100,
+		"CompletionTokens": 50,
+	})
+	if usage.Input != 100 || usage.Output != 50 {
+		t.Errorf("Expected usage input=100 output=50, got input=%d output=%d", usage.Input, usage.Output)
+	}
+}

--- a/backend/pkg/providers/minimax/models.yml
+++ b/backend/pkg/providers/minimax/models.yml
@@ -1,0 +1,20 @@
+- name: MiniMax-M3
+  description: MiniMax-M3 - Latest flagship model with 512K context window, up to 128K output tokens, and image input support. Suitable for general dialogue, code generation, complex reasoning, and tool calling.
+  thinking: false
+  price:
+    input: 0.60
+    output: 2.40
+
+- name: MiniMax-M2.7
+  description: MiniMax-M2.7 - Previous flagship model with enhanced reasoning and coding capabilities. Supports tool calling, JSON output, and streaming.
+  thinking: false
+  price:
+    input: 0.40
+    output: 1.10
+
+- name: MiniMax-M2.7-highspeed
+  description: MiniMax-M2.7-highspeed - High-speed version of M2.7 for low-latency scenarios. Same capabilities as M2.7 with improved response latency.
+  thinking: false
+  price:
+    input: 0.40
+    output: 1.10

--- a/backend/pkg/providers/provider/provider.go
+++ b/backend/pkg/providers/provider/provider.go
@@ -30,6 +30,7 @@ const (
 	ProviderGLM       ProviderType = "glm"
 	ProviderKimi      ProviderType = "kimi"
 	ProviderQwen      ProviderType = "qwen"
+	ProviderMiniMax   ProviderType = "minimax"
 )
 
 type ProviderName string
@@ -49,6 +50,7 @@ const (
 	DefaultProviderNameGLM       ProviderName = ProviderName(ProviderGLM)
 	DefaultProviderNameKimi      ProviderName = ProviderName(ProviderKimi)
 	DefaultProviderNameQwen      ProviderName = ProviderName(ProviderQwen)
+	DefaultProviderNameMiniMax   ProviderName = ProviderName(ProviderMiniMax)
 )
 
 type Provider interface {

--- a/backend/pkg/providers/providers.go
+++ b/backend/pkg/providers/providers.go
@@ -27,6 +27,7 @@ import (
 	"pentagi/pkg/providers/gemini"
 	"pentagi/pkg/providers/glm"
 	"pentagi/pkg/providers/kimi"
+	"pentagi/pkg/providers/minimax"
 	"pentagi/pkg/providers/ollama"
 	"pentagi/pkg/providers/openai"
 	"pentagi/pkg/providers/pconfig"
@@ -235,6 +236,12 @@ func NewProviderController(
 		defaultConfigs[provider.ProviderQwen] = config
 	}
 
+	if config, err := minimax.DefaultProviderConfig(); err != nil {
+		return nil, fmt.Errorf("failed to create minimax provider config: %w", err)
+	} else {
+		defaultConfigs[provider.ProviderMiniMax] = config
+	}
+
 	if cfg.OpenAIKey != "" {
 		p, err := openai.New(cfg, provider.DefaultProviderNameOpenAI, defaultConfigs[provider.ProviderOpenAI])
 		if err != nil {
@@ -326,6 +333,15 @@ func NewProviderController(
 		}
 
 		providers[provider.DefaultProviderNameQwen] = p
+	}
+
+	if cfg.MiniMaxAPIKey != "" {
+		p, err := minimax.New(cfg, provider.DefaultProviderNameMiniMax, defaultConfigs[provider.ProviderMiniMax])
+		if err != nil {
+			return nil, fmt.Errorf("failed to create minimax provider: %w", err)
+		}
+
+		providers[provider.DefaultProviderNameMiniMax] = p
 	}
 
 	summarizerAgent := csum.NewSummarizer(csum.SummarizerConfig{
@@ -734,6 +750,8 @@ func (pc *providerController) GetProvider(
 		return pc.Providers.Get(provider.DefaultProviderNameKimi)
 	case provider.DefaultProviderNameQwen:
 		return pc.Providers.Get(provider.DefaultProviderNameQwen)
+	case provider.DefaultProviderNameMiniMax:
+		return pc.Providers.Get(provider.DefaultProviderNameMiniMax)
 	}
 
 	return nil, fmt.Errorf("provider '%s' not found", prvname)
@@ -840,6 +858,12 @@ func (pc *providerController) NewProvider(prv database.Provider) (provider.Provi
 			return nil, fmt.Errorf("failed to build qwen provider config: %w", err)
 		}
 		return qwen.New(pc.cfg, providerName, qwenConfig)
+	case provider.ProviderMiniMax:
+		minimaxConfig, err := minimax.BuildProviderConfig(prv.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build minimax provider config: %w", err)
+		}
+		return minimax.New(pc.cfg, providerName, minimaxConfig)
 	default:
 		return nil, fmt.Errorf("unknown provider type: %s", prv.Type)
 	}
@@ -1178,6 +1202,8 @@ func (pc *providerController) buildProviderFromConfig(
 		return kimi.New(pc.cfg, prvname, config)
 	case provider.ProviderQwen:
 		return qwen.New(pc.cfg, prvname, config)
+	case provider.ProviderMiniMax:
+		return minimax.New(pc.cfg, prvname, config)
 	default:
 		return nil, fmt.Errorf("unknown provider type: %s", prvtype)
 	}

--- a/backend/pkg/server/models/providers.go
+++ b/backend/pkg/server/models/providers.go
@@ -29,7 +29,8 @@ func (s ProviderType) Valid() error {
 		provider.ProviderDeepSeek,
 		provider.ProviderGLM,
 		provider.ProviderKimi,
-		provider.ProviderQwen:
+		provider.ProviderQwen,
+		provider.ProviderMiniMax:
 		return nil
 	default:
 		return fmt.Errorf("invalid ProviderType: %s", s)


### PR DESCRIPTION
## Summary
Add MiniMax provider to PentAGI with **MiniMax-M3 as the default model**, keeping MiniMax-M2.7 and MiniMax-M2.7-highspeed as alternatives.

## Changes
- Add new `MiniMax` provider package (`backend/pkg/providers/minimax/`) implementing the `provider.Provider` interface via the OpenAI-compatible `https://api.minimax.io/v1` endpoint.
- Set **MiniMax-M3** as the default model for all agent types (simple, primary_agent, assistant, generator, refiner, adviser, reflector, searcher, enricher, coder, installer, pentester).
- Keep **MiniMax-M2.7** and **MiniMax-M2.7-highspeed** in the model list as alternatives.
- Register `ProviderMiniMax` type, `DefaultProviderNameMiniMax` name, and wire the provider into `NewProviderController` / `NewProvider` / `buildProviderFromConfig` / `buildProviderFromConfig` / `GetProvider` paths.
- Add env vars `MINIMAX_API_KEY`, `MINIMAX_SERVER_URL` (default `https://api.minimax.io/v1`), `MINIMAX_PROVIDER` and the matching secret pattern.
- Add `provider.ProviderMiniMax` to the `Valid()` whitelist in `pkg/server/models/providers.go` (required for REST API acceptance).
- Unit tests covering config loading, default-model sanity, models list (`M3` first, no legacy `M1/M2/M2.1/M2.5`), model prefix behaviour, and missing-API-key error.

## Why
MiniMax-M3 is MiniMax's latest flagship model (512K context, 128K max output, image input support) and is the right default for a security-testing workload that benefits from large context and multimodal input. MiniMax-M2.7 and its high-speed variant are retained for users who want to pin to the previous generation.

## Model list
- `MiniMax-M3` (default) — 512K context, 128K output, image input, input $0.60 / output $2.40 per 1M tokens
- `MiniMax-M2.7` — input $0.40 / output $1.10
- `MiniMax-M2.7-highspeed` — input $0.40 / output $1.10

No legacy models (`MiniMax-M1` / `MiniMax-M2` / `MiniMax-M2.1` / `MiniMax-M2.5`) are included.

## API docs
- OpenAI-compatible Chat: https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo

## Testing
- `go test ./pkg/providers/minimax/...` — 7/7 passing (config loading, provider type, models list with M3 as first entry, prefix behaviour, missing key, usage extraction).
- `go build ./pkg/providers/minimax/...` — clean.