### PR TITLE
docs: add tool-call parser troubleshooting for custom LLM backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,6 +1392,26 @@ The `LLM_SERVER_PRESERVE_REASONING` setting controls whether reasoning content i
 
 This setting is required by some LLM providers (e.g., Moonshot) that return errors like "thinking is enabled but reasoning_content is missing in assistant tool call message" when reasoning content is not included in multi-turn conversations. Enable this setting if your provider requires reasoning content to be preserved.
 
+#### Troubleshooting: tool-call (function-call) parser errors
+
+PentAGI drives its agents with tool calls (also called function calls), so any custom OpenAI-compatible backend configured through `LLM_SERVER_*` must return valid tool-call JSON in the format the OpenAI Chat Completions API defines. When the backend emits malformed, truncated, or non-conforming tool-call arguments, the agent chain cannot continue.
+
+Self-hosted engines such as llama.cpp, SGLang, and vLLM usually require a specific tool-call parser and a matching chat template to produce correct tool-call output. If the parser is missing or mismatched for the model you are serving, tool-call arguments can come back corrupted. Compatibility therefore depends on the backend's tool-call/function-call behavior and configuration, not on PentAGI alone; not every llama.cpp or SGLang setup produces valid tool calls out of the box.
+
+Typical symptoms:
+
+- Backend or proxy errors such as `Failed to parse tool call arguments as JSON` (often surfaced through a LiteLLM proxy as an HTTP 500), or other unexpected 5xx/4xx responses from the LLM endpoint.
+- A flow that runs for a few steps and then stops responding to new input in the UI.
+- Repeated or looping tool calls that never converge.
+- A flow that fails right at the start with `failed to select primary docker image via llm call`, because the first action in a flow is an LLM tool call to choose the container image; a backend that cannot return a valid tool call fails at this step too.
+
+How to investigate:
+
+1. Check both sides of the connection: the PentAGI logs (`docker compose logs -f pentagi`) and the inference backend or proxy logs (llama.cpp, SGLang, vLLM, or LiteLLM). The backend log usually shows the same parse error when it produced the malformed tool call.
+2. Validate the provider before running a full flow with the `ctester` utility, which exercises tool-calling agent types directly. See [Testing LLM Agents](https://github.com/vxcontrol/pentagi#testing-llm-agents).
+3. Confirm the backend's tool-call parser and chat template are the ones recommended for the model you are serving, and that the model itself supports tool calling.
+4. Update PentAGI to the latest build. Recent versions sanitize malformed function-call arguments returned by the model so a single bad response no longer stalls the whole flow; older builds forwarded the corrupted arguments and could get stuck.
+
 ### Ollama Provider Configuration
 
 PentAGI supports Ollama for both local LLM inference (zero-cost, enhanced privacy) and Ollama Cloud (managed service with free tier).


### PR DESCRIPTION
## Summary

Add a troubleshooting subsection under **Custom LLM Provider Configuration** explaining why tool-call (function-call) parser problems on self-hosted OpenAI-compatible backends (llama.cpp / SGLang / vLLM, often behind LiteLLM) cause stalled flows, and how to diagnose them. Docs only.

## Problem

Issue #313 reported that flows stop responding after a few steps when running a custom backend configured through `LLM_SERVER_*` (LiteLLM in front of llama.cpp serving `qwen3.6-35b`). The logs showed:

```
Failed to parse tool call arguments as JSON: [json.exception.parse_error.101]
parse error at line 1, column 131: syntax error while parsing value -
unexpected end of input
```

surfaced through LiteLLM as an HTTP 500, followed by cascading retries and a 429. The maintainer confirmed the stall was fixed in the latest build by sanitizing malformed function-call arguments, and that the root cause was the model side returning corrupted tool-call arguments.

There is currently no documentation that explains this class of failure, even though it is a common pitfall with self-hosted backends and is closely related to the image-chooser failure (a flow's first action is an LLM tool call to pick the container image).

## Solution

Add a `#### Troubleshooting: tool-call (function-call) parser errors` subsection right after the Custom LLM Provider Configuration content, covering:

- Custom OpenAI-compatible backends must return valid tool-call JSON; llama.cpp, SGLang, and vLLM usually require a specific tool-call parser and a matching chat template, and not every setup produces valid tool calls out of the box (compatibility depends on the backend, not PentAGI alone).
- Symptoms: `Failed to parse tool call arguments as JSON`, a flow that stalls after a few steps, looping tool calls, the start-of-flow `failed to select primary docker image via llm call` error, and unexpected backend 5xx/4xx responses.
- How to investigate: check both PentAGI and backend/proxy logs, validate the provider with `ctester` before a full flow, confirm the parser/chat template match the model, and update PentAGI (recent builds sanitize malformed function-call arguments).

The new content links only to the existing [Testing LLM Agents](https://github.com/vxcontrol/pentagi#testing-llm-agents) section and references the image-chooser error in prose (no new anchor), so it stands on its own against `main`.

## User Impact

- Users on self-hosted/llama.cpp/SGLang/vLLM backends get a clear explanation of the tool-call parser failure mode and a concrete diagnosis path, instead of an opaque `Failed to parse tool call arguments as JSON` stall.
- Points users at `ctester` for pre-flight validation and at the update that sanitizes malformed arguments.
- No behavior change.

## Test Plan

- [x] `git diff --check` clean.
- [x] Docs-only diff: `README.md` (+20 lines). No tool-call parser code, provider runtime, schema, migration, or config-default changes.
- [x] Verified the referenced error string `failed to select primary docker image via llm call` exists in `backend/pkg/providers/providers.go` on `main`.
- [x] Verified `LLM_SERVER_URL` / `LLM_SERVER_KEY` / `LLM_SERVER_MODEL` / `LLM_SERVER_PROVIDER` exist in `.env.example`.
- [x] Verified the `ctester` utility exists and tests tool-calling agent types, and that the `#testing-llm-agents` anchor resolves.
- [x] Placed away from the README regions touched by open PRs #325 and #327 to avoid conflicts.
- [x] No unrelated files included.

Refs #313