### PR TITLE
Update user Email Address

### DIFF
--- a/backend/pkg/server/models/users.go
+++ b/backend/pkg/server/models/users.go
@@ -170,6 +170,7 @@ type Password struct {
 	CurrentPassword string `form:"current_password" json:"current_password" validate:"nefield=Password,min=5,max=100,required" gorm:"-"`
 	Password        string `form:"password" json:"password" validate:"stpass,max=100,required" gorm:"type:TEXT"`
 	ConfirmPassword string `form:"confirm_password" json:"confirm_password" validate:"eqfield=Password" gorm:"-"`
+	Mail            string `form:"mail,omitempty" json:"mail,omitempty" validate:"omitempty,max=50,vmail" gorm:"-"`
 }
 
 // TableName returns the table name string to guaranty use correct table

--- a/backend/pkg/server/response/errors.go
+++ b/backend/pkg/server/response/errors.go
@@ -44,6 +44,7 @@ var ErrUsersInvalidRequest = NewHttpError(400, "Users.InvalidRequest", "invalid 
 var ErrChangePasswordCurrentUserInvalidPassword = NewHttpError(400, "Users.ChangePasswordCurrentUser.InvalidPassword", "failed to validate user password")
 var ErrChangePasswordCurrentUserInvalidCurrentPassword = NewHttpError(403, "Users.ChangePasswordCurrentUser.InvalidCurrentPassword", "invalid current password")
 var ErrChangePasswordCurrentUserInvalidNewPassword = NewHttpError(400, "Users.ChangePasswordCurrentUser.InvalidNewPassword", "invalid new password form data")
+var ErrChangePasswordCurrentUserMailExists = NewHttpError(409, "Users.ChangePasswordCurrentUser.MailExists", "email already exists")
 var ErrGetUserModelsNotFound = NewHttpError(404, "Users.GetUser.ModelsNotFound", "user linked models not found")
 var ErrCreateUserInvalidUser = NewHttpError(400, "Users.CreateUser.InvalidUser", "failed to validate user")
 var ErrPatchUserModelsNotFound = NewHttpError(404, "Users.PatchUser.ModelsNotFound", "user linked models not found")

--- a/backend/pkg/server/response/http_test.go
+++ b/backend/pkg/server/response/http_test.go
@@ -91,6 +91,7 @@ func TestPredefinedErrors(t *testing.T) {
 		{"ErrChangePasswordCurrentUserInvalidPassword", ErrChangePasswordCurrentUserInvalidPassword, 400, "Users.ChangePasswordCurrentUser.InvalidPassword"},
 		{"ErrChangePasswordCurrentUserInvalidCurrentPassword", ErrChangePasswordCurrentUserInvalidCurrentPassword, 403, "Users.ChangePasswordCurrentUser.InvalidCurrentPassword"},
 		{"ErrChangePasswordCurrentUserInvalidNewPassword", ErrChangePasswordCurrentUserInvalidNewPassword, 400, "Users.ChangePasswordCurrentUser.InvalidNewPassword"},
+		{"ErrChangePasswordCurrentUserMailExists", ErrChangePasswordCurrentUserMailExists, 409, "Users.ChangePasswordCurrentUser.MailExists"},
 		{"ErrGetUserModelsNotFound", ErrGetUserModelsNotFound, 404, "Users.GetUser.ModelsNotFound"},
 		{"ErrCreateUserInvalidUser", ErrCreateUserInvalidUser, 400, "Users.CreateUser.InvalidUser"},
 		{"ErrPatchUserModelsNotFound", ErrPatchUserModelsNotFound, 404, "Users.PatchUser.ModelsNotFound"},

--- a/backend/pkg/server/services/users.go
+++ b/backend/pkg/server/services/users.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"slices"
+	"strings"
 
 	"pentagi/pkg/server/auth"
 	"pentagi/pkg/server/logger"
@@ -116,6 +117,7 @@ func (s *UserService) GetCurrentUser(c *gin.Context) {
 // @Failure 400 {object} response.errorResp "invalid account password form data"
 // @Failure 403 {object} response.errorResp "updating account password not permitted"
 // @Failure 404 {object} response.errorResp "current user not found"
+// @Failure 409 {object} response.errorResp "email already exists"
 // @Failure 500 {object} response.errorResp "internal error on updating account password"
 // @Router /user/password [put]
 func (s *UserService) ChangePasswordCurrentUser(c *gin.Context) {
@@ -126,11 +128,15 @@ func (s *UserService) ChangePasswordCurrentUser(c *gin.Context) {
 		user    models.UserPassword
 	)
 
-	if err = c.ShouldBindJSON(&form); err != nil || form.Valid() != nil {
-		if err == nil {
-			err = form.Valid()
-		}
+	if err = c.ShouldBindJSON(&form); err != nil {
 		logger.FromContext(c).WithError(err).Errorf("error binding JSON")
+		response.Error(c, response.ErrChangePasswordCurrentUserInvalidPassword, err)
+		return
+	}
+
+	form.Mail = strings.ToLower(strings.TrimSpace(form.Mail))
+	if err = form.Valid(); err != nil {
+		logger.FromContext(c).WithError(err).Errorf("error validating password profile form")
 		response.Error(c, response.ErrChangePasswordCurrentUserInvalidPassword, err)
 		return
 	}
@@ -171,9 +177,28 @@ func (s *UserService) ChangePasswordCurrentUser(c *gin.Context) {
 		"password":                 string(encPass),
 		"password_change_required": false,
 	}
+	if form.Mail != "" && form.Mail != user.Mail {
+		var count int
+		if err = s.db.Model(&models.User{}).Where("mail = ? AND id <> ?", form.Mail, uid).Count(&count).Error; err != nil {
+			logger.FromContext(c).WithError(err).Errorf("error checking mail uniqueness for current user")
+			response.Error(c, response.ErrInternal, err)
+			return
+		}
+		if count > 0 {
+			logger.FromContext(c).Errorf("email already exists for another user")
+			response.Error(c, response.ErrChangePasswordCurrentUserMailExists, nil)
+			return
+		}
+
+		updates["mail"] = form.Mail
+	}
 
 	if err = s.db.Model(&user).Scopes(scope).Updates(updates).Error; err != nil {
 		logger.FromContext(c).WithError(err).Errorf("error updating password for current user")
+		if strings.Contains(strings.ToLower(err.Error()), "unique") {
+			response.Error(c, response.ErrChangePasswordCurrentUserMailExists, err)
+			return
+		}
 		response.Error(c, response.ErrInternal, err)
 		return
 	}

--- a/backend/pkg/server/services/users_test.go
+++ b/backend/pkg/server/services/users_test.go
@@ -9,12 +9,14 @@ import (
 
 	"pentagi/pkg/server/auth"
 	"pentagi/pkg/server/models"
+	"pentagi/pkg/server/rdb"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestCreateUser_CreatesUserPreferences(t *testing.T) {
@@ -351,4 +353,77 @@ func TestCreateUser_DuplicateEmail(t *testing.T) {
 	var count int
 	db.Model(&models.User{}).Where("mail = ?", "duplicate@test.com").Count(&count)
 	assert.Equal(t, 1, count, "Should have only one user with this email")
+}
+
+func TestChangePasswordCurrentUser_WithChangedEmail(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedLocalPassword(t, db, 1, "OldPass123!", true)
+
+	service := NewUserService(db, auth.NewUserCache(db))
+	c, w := setupTestContext(1, 2, "testhash1", nil)
+	setPasswordChangeRequest(t, c, models.Password{
+		CurrentPassword: "OldPass123!",
+		Password:        "NewPass123!",
+		ConfirmPassword: "NewPass123!",
+		Mail:            "changed@test.com",
+	})
+
+	service.ChangePasswordCurrentUser(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var user models.UserPassword
+	require.NoError(t, db.Where("id = ?", 1).Take(&user).Error)
+	assert.Equal(t, "changed@test.com", user.Mail)
+	assert.False(t, user.PasswordChangeRequired)
+	require.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.Password), []byte("NewPass123!")))
+}
+
+func TestChangePasswordCurrentUser_DuplicateEmail(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedLocalPassword(t, db, 1, "OldPass123!", true)
+
+	service := NewUserService(db, auth.NewUserCache(db))
+	c, w := setupTestContext(1, 2, "testhash1", nil)
+	setPasswordChangeRequest(t, c, models.Password{
+		CurrentPassword: "OldPass123!",
+		Password:        "NewPass123!",
+		ConfirmPassword: "NewPass123!",
+		Mail:            "user2@test.com",
+	})
+
+	service.ChangePasswordCurrentUser(c)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	var user models.UserPassword
+	require.NoError(t, db.Where("id = ?", 1).Take(&user).Error)
+	assert.Equal(t, "user1@test.com", user.Mail)
+	require.NoError(t, bcrypt.CompareHashAndPassword([]byte(user.Password), []byte("OldPass123!")))
+}
+
+func seedLocalPassword(t *testing.T, db *gorm.DB, userID uint64, password string, passwordChangeRequired bool) string {
+	t.Helper()
+
+	encPassword, err := rdb.EncryptPassword(password)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", userID).Updates(map[string]any{
+		"password":                 string(encPassword),
+		"password_change_required": passwordChangeRequired,
+	}).Error)
+
+	return string(encPassword)
+}
+
+func setPasswordChangeRequest(t *testing.T, c *gin.Context, password models.Password) {
+	t.Helper()
+
+	body, err := json.Marshal(password)
+	require.NoError(t, err)
+
+	c.Request, _ = http.NewRequest("PUT", "/user/password", bytes.NewBuffer(body))
+	c.Request.Header.Set("Content-Type", "application/json")
 }

--- a/frontend/src/components/layouts/main-sidebar.tsx
+++ b/frontend/src/components/layouts/main-sidebar.tsx
@@ -5,7 +5,6 @@ import {
     FileText,
     Folder,
     GitFork,
-    KeyRound,
     LayoutDashboard,
     LibraryBig,
     LogOut,
@@ -64,7 +63,7 @@ interface FlowMenuItemProps {
 }
 
 export function MainSidebar() {
-    const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
+    const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
     const isDashboardActive = useMatch('/dashboard');
     const isFlowsActive = useMatch('/flows/*');
     const isTemplatesActive = useMatch('/templates/*');
@@ -359,9 +358,9 @@ export function MainSidebar() {
                                 {user?.type === 'local' && (
                                     <>
                                         <DropdownMenuSeparator />
-                                        <DropdownMenuItem onClick={() => setIsPasswordModalOpen(true)}>
-                                            <KeyRound className="mr-2 size-4" />
-                                            Change Password
+                                        <DropdownMenuItem onClick={() => setIsProfileModalOpen(true)}>
+                                            <UserIcon className="mr-2 size-4" />
+                                            Profile
                                         </DropdownMenuItem>
                                     </>
                                 )}
@@ -389,16 +388,16 @@ export function MainSidebar() {
             />
 
             <Dialog
-                onOpenChange={setIsPasswordModalOpen}
-                open={isPasswordModalOpen}
+                onOpenChange={setIsProfileModalOpen}
+                open={isProfileModalOpen}
             >
                 <DialogContent className="sm:max-w-[425px]">
                     <DialogHeader>
-                        <DialogTitle>Change Password</DialogTitle>
+                        <DialogTitle>Profile</DialogTitle>
                     </DialogHeader>
                     <PasswordChangeForm
-                        onCancel={() => setIsPasswordModalOpen(false)}
-                        onSuccess={() => setIsPasswordModalOpen(false)}
+                        onCancel={() => setIsProfileModalOpen(false)}
+                        onSuccess={() => setIsProfileModalOpen(false)}
                     />
                 </DialogContent>
             </Dialog>

--- a/frontend/src/features/authentication/password-change-form.tsx
+++ b/frontend/src/features/authentication/password-change-form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -10,11 +10,15 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import { FormSubmitButton } from '@/components/ui/form-submit-button';
 import { Input } from '@/components/ui/input';
 import { api, type ApiErrorResponse, type ApiHttpError } from '@/lib/axios';
+import { useUser } from '@/providers/user-provider';
 
 const passwordChangeSchema = z
     .object({
         confirmPassword: z.string().min(1, { message: 'Confirm your password' }),
         currentPassword: z.string().min(1, { message: 'Current password is required' }),
+        email: z.string().email({ message: 'Enter a valid email address' }).max(50, {
+            message: 'Email must not exceed 50 characters',
+        }),
         newPassword: z
             .string()
             .min(8, { message: 'Password must be at least 8 characters' })
@@ -66,14 +70,18 @@ export function PasswordChangeForm({
     showSkip = false,
 }: PasswordChangeFormProps) {
     const [error, setError] = useState<null | string>(null);
+    const [isEmailEditable, setIsEmailEditable] = useState(false);
     const [showCurrentPassword, setShowCurrentPassword] = useState(false);
     const [showNewPassword, setShowNewPassword] = useState(false);
     const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+    const { authInfo, refreshAuthInfo } = useUser();
+    const currentEmail = authInfo?.user?.mail || '';
 
     const form = useForm<PasswordChangeFormValues>({
         defaultValues: {
             confirmPassword: '',
             currentPassword: '',
+            email: currentEmail,
             newPassword: '',
         },
         resolver: zodResolver(passwordChangeSchema),
@@ -81,20 +89,40 @@ export function PasswordChangeForm({
 
     const handleSubmit = async (values: PasswordChangeFormValues) => {
         setError(null);
+        const nextEmail = values.email.trim().toLowerCase();
+        const emailChanged = nextEmail !== currentEmail.trim().toLowerCase();
 
         try {
-            await api.put('/user/password', {
+            const payload: {
+                confirm_password: string;
+                current_password: string;
+                mail?: string;
+                password: string;
+            } = {
                 confirm_password: values.confirmPassword,
                 current_password: values.currentPassword,
                 password: values.newPassword,
-            });
+            };
 
-            form.reset();
+            if (emailChanged) {
+                payload.mail = nextEmail;
+            }
+
+            await api.put('/user/password', payload);
+            await refreshAuthInfo();
+
+            form.reset({
+                confirmPassword: '',
+                currentPassword: '',
+                email: nextEmail,
+                newPassword: '',
+            });
+            setIsEmailEditable(false);
             setShowCurrentPassword(false);
             setShowNewPassword(false);
             setShowConfirmPassword(false);
 
-            toast.success('Password successfully changed');
+            toast.success(emailChanged ? 'Profile successfully updated' : 'Password successfully changed');
 
             if (onSuccess) {
                 onSuccess();
@@ -117,6 +145,9 @@ export function PasswordChangeForm({
                         break;
                     case 'Users.ChangePasswordCurrentUser.InvalidNewPassword':
                         errorMessage = 'New password does not meet requirements';
+                        break;
+                    case 'Users.ChangePasswordCurrentUser.MailExists':
+                        errorMessage = 'Email is already in use';
                         break;
                     case 'Users.ChangePasswordCurrentUser.InvalidPassword':
                         errorMessage = 'Password validation failed';
@@ -141,6 +172,38 @@ export function PasswordChangeForm({
                 className="flex flex-col gap-4"
                 onSubmit={form.handleSubmit(handleSubmit)}
             >
+                <FormField
+                    control={form.control}
+                    name="email"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Email</FormLabel>
+                            <FormControl>
+                                <div className="relative">
+                                    <Input
+                                        {...field}
+                                        className={!isEmailEditable ? 'cursor-pointer pr-10' : 'pr-10'}
+                                        onClick={() => setIsEmailEditable(true)}
+                                        readOnly={!isEmailEditable}
+                                    />
+                                    <Button
+                                        aria-label="Edit email"
+                                        className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
+                                        onClick={() => setIsEmailEditable(true)}
+                                        size="sm"
+                                        tabIndex={-1}
+                                        type="button"
+                                        variant="ghost"
+                                    >
+                                        <Pencil className="text-muted-foreground size-4" />
+                                    </Button>
+                                </div>
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+
                 <FormField
                     control={form.control}
                     name="currentPassword"
@@ -270,7 +333,7 @@ export function PasswordChangeForm({
                         </Button>
                     )}
                     <FormSubmitButton>
-                        <span>Update Password</span>
+                        <span>Save Profile</span>
                     </FormSubmitButton>
                 </div>
             </form>


### PR DESCRIPTION
This PR adds support for local users to update their profile email address from the Web UI.

## Changes

* Renamed the sidebar action from **Change Password** to **Profile**.
* Added an editable email field to the profile form.
* Sends the updated email address to the backend only when it has changed.
* Normalizes email input by trimming whitespace and converting it to lowercase.
* Refreshes the current user info after a successful profile update.
* Added backend validation for the optional email field.
* Added duplicate email detection with a `409 Conflict` response.
* Added tests for successful email update and duplicate email handling.

## Motivation

Local users were able to change their password, but not update the email address associated with their profile. This improves account/profile management from the Web UI.

## Testing

Added backend tests for:

* Updating the current user's email address successfully.
* Preventing email updates when the new email is already used by another user.

**I am happy to make any changes requested during review. , Thank You!**
