### PR TITLE
fix: avoid unsupported XSStrike flags in pentester prompt

### DIFF
--- a/backend/pkg/templates/prompts/pentester.tmpl
+++ b/backend/pkg/templates/prompts/pentester.tmpl
@@ -323,6 +323,12 @@ Check tool availability with 'which [tool]' before use. Install missing tools if
 {{end}}
 </usage_notes>
 
+<cli_argument_protocol>
+- Verify command-specific flags with `[tool] -h` or `[tool] --help` before first use when the exact syntax is uncertain.
+- Do not copy flags between different tools. For XSStrike, do not use `xsstrike -c` or `xsstrike -o` unless the installed `xsstrike --help` explicitly documents those options.
+- If output needs to be saved or reduced, prefer shell redirection or the tool's documented logging option instead of inventing unsupported output flags.
+</cli_argument_protocol>
+
 <msf_workflow_protocol>
 Standalone (recommended): All operations in one command
 `msfconsole -q -x "use exploit/...; set LPORT [allocated]; exploit; sleep 20; sessions -l; sessions -i 1 -c 'sysinfo'; exit"`

--- a/backend/pkg/templates/prompts/pentester.tmpl
+++ b/backend/pkg/templates/prompts/pentester.tmpl
@@ -325,8 +325,9 @@ Check tool availability with 'which [tool]' before use. Install missing tools if
 
 <cli_argument_protocol>
 - Verify command-specific flags with `[tool] -h` or `[tool] --help` before first use when the exact syntax is uncertain.
-- Do not copy flags between different tools. For XSStrike, do not use `xsstrike -c` or `xsstrike -o` unless the installed `xsstrike --help` explicitly documents those options.
-- If output needs to be saved or reduced, prefer shell redirection or the tool's documented logging option instead of inventing unsupported output flags.
+- Do not copy flags between different tools, and do not invent output flags: do not pass `-c`, `-o`, or `-o /dev/null` to a tool unless that tool's own `--help` documents them.
+- For XSStrike specifically, do not use `xsstrike -c` or `xsstrike -o` (including `xsstrike -o /dev/null`); XSStrike does not accept these arguments. Confirm the exact flags with `xsstrike --help`.
+- If output needs to be saved, reduced, or discarded, use shell redirection (for example, `> results.txt` or `> /dev/null`) or the tool's documented logging option instead of inventing unsupported output flags.
 </cli_argument_protocol>
 
 <msf_workflow_protocol>

--- a/backend/pkg/templates/templates_test.go
+++ b/backend/pkg/templates/templates_test.go
@@ -1013,6 +1013,42 @@ func TestQuestionTaskPlannerPrompt(t *testing.T) {
 	}
 }
 
+// TestPentesterPromptXSStrikeArgumentGuidance keeps the pentester prompt from
+// recommending unsupported XSStrike flags when composing terminal commands.
+func TestPentesterPromptXSStrikeArgumentGuidance(t *testing.T) {
+	defaultPrompts, err := templates.GetDefaultPrompts()
+	if err != nil {
+		t.Fatalf("Failed to load default prompts: %v", err)
+	}
+
+	dummyData := validator.CreateDummyTemplateData()
+	template := defaultPrompts.AgentsPrompts.Pentester.System.Template
+
+	rendered, err := templates.RenderPrompt(
+		string(templates.PromptTypePentester),
+		template,
+		dummyData,
+	)
+	if err != nil {
+		t.Fatalf("Failed to render pentester template: %v", err)
+	}
+
+	requiredGuidance := []string{
+		"cli_argument_protocol",
+		"XSStrike",
+		"xsstrike --help",
+		"xsstrike -c",
+		"xsstrike -o",
+		"inventing unsupported output flags",
+	}
+
+	for _, guidance := range requiredGuidance {
+		if !strings.Contains(rendered, guidance) {
+			t.Errorf("Rendered pentester template missing XSStrike argument guidance: %s", guidance)
+		}
+	}
+}
+
 // TestTaskAssignmentWrapperPrompt tests the task_assignment_wrapper template
 func TestTaskAssignmentWrapperPrompt(t *testing.T) {
 	defaultPrompts, err := templates.GetDefaultPrompts()

--- a/backend/pkg/templates/templates_test.go
+++ b/backend/pkg/templates/templates_test.go
@@ -1039,6 +1039,8 @@ func TestPentesterPromptXSStrikeArgumentGuidance(t *testing.T) {
 		"xsstrike --help",
 		"xsstrike -c",
 		"xsstrike -o",
+		"xsstrike -o /dev/null",
+		"shell redirection",
 		"inventing unsupported output flags",
 	}
 


### PR DESCRIPTION
## Summary

Add a narrow Pentester prompt guardrail for XSStrike command construction and cover it with a template-rendering regression test.

## Problem

Issue #335 reports PentAGI executing `xsstrike` with unsupported `-c` and `-o /dev/null` arguments. Investigation did not find a hardcoded XSStrike command or `-c -o /dev/null` pattern in repo prompts, schemas, config, examples, or docs. The issue evidence shows the installed XSStrike help output rejects those flags, so the likely failure mode is model-generated CLI flag reuse during pentest command composition.

## Solution

Update `backend/pkg/templates/prompts/pentester.tmpl` with a small CLI argument protocol that tells the Pentester agent to verify tool-specific flags, avoid copying flags across tools, and specifically avoid `xsstrike -c` or `xsstrike -o` unless the installed `xsstrike --help` documents them.

Add `TestPentesterPromptXSStrikeArgumentGuidance` to ensure the rendered Pentester prompt keeps this guardrail in place.

## User Impact

Users running XSS testing flows should be less likely to hit the reported XSStrike argument error. This does not change runtime tool execution, Docker image contents, schemas, frontend behavior, or unrelated tools.

## Test Plan

- `go test ./pkg/templates` - passed in a Go-enabled verification environment.
- `git diff --check` - passed.
- `rg -n -i "xsstrike|xss strike|xssstrike" backend frontend examples README.md --glob '!backend/pkg/tools/testdata/sploitus_result_nginx.json'` - only the new guardrail and regression test mention XSStrike.
- `rg -n -- "xsstrike -c|xsstrike -o|-o /dev/null|unrecognized arguments" backend frontend examples README.md` - only the new negative guidance/test references `xsstrike -c` and `xsstrike -o`; no stale executable example remains.
- `docker image ls vxcontrol/kali-linux` / `xsstrike --help` - not run locally because Docker is not installed in this environment; XSStrike CLI behavior was verified from the Issue #335 evidence.

Refs #335

## Update: guardrail hardening

- The CLI argument protocol now explicitly forbids `xsstrike -o /dev/null` (the exact flag combination reported in #335) and documents the correct alternative for saving, reducing, or discarding output (shell redirection such as `> /dev/null`), addressing the root cause: the model substituting an unsupported output flag.
- `TestPentesterPromptXSStrikeArgumentGuidance` was extended to also assert the `xsstrike -o /dev/null` negative guidance and the shell-redirection alternative.

Validation limitation: this is a prompt-level guardrail; it reduces but cannot guarantee model behavior. Runtime reproduction of #335 against a live PentAGI + LLM was not performed in this environment, so efficacy is validated structurally (the prompt now names the exact failing flags and the supported alternative) and via the template regression test, not by live execution.
