### PR TITLE
docs: add Qwen long-flow troubleshooting

### DIFF
--- a/backend/docs/flow_execution.md
+++ b/backend/docs/flow_execution.md
@@ -975,6 +975,8 @@ PentAGI implements a sophisticated multi-layered agent supervision system to ens
 - `EXECUTION_MONITOR_SAME_TOOL_LIMIT` (default: 5) - Consecutive same-tool threshold
 - `EXECUTION_MONITOR_TOTAL_TOOL_LIMIT` (default: 10) - Total tool calls threshold
 
+For local or custom Qwen-style deployments where flows run for hours or repeat commands, see the [vLLM Qwen3.5-27B-FP8 troubleshooting guide](../../examples/guides/vllm-qwen35-27b-fp8.md#issue-automation-flow-runs-for-hours-or-repeats-commands) for prompt-bounding and log-review guidance.
+
 ### Enhanced Reflector Integration
 
 **Automatic Reflector on Generation Failures**:

--- a/examples/guides/vllm-qwen35-27b-fp8.md
+++ b/examples/guides/vllm-qwen35-27b-fp8.md
@@ -337,6 +337,28 @@ These benchmarks demonstrate that Qwen3.5-27B-FP8 provides excellent throughput 
 
 ## Troubleshooting
 
+### Issue: Automation Flow Runs for Hours or Repeats Commands
+
+**Cause**: Broad penetration testing prompts can leave smaller local or custom models exploring too much state, especially when the task has no stopping criteria. Repeated commands may indicate model weakness, target complexity, tool-call/provider issues, or a flow that needs additional supervision.
+
+**Solution**: First check the existing PentAGI execution controls before changing runtime behavior or assuming the target is broken:
+
+- Enable execution monitoring with `EXECUTION_MONITOR_ENABLED=true` so the Adviser can review repeated or inefficient tool-call patterns.
+- Tune `EXECUTION_MONITOR_SAME_TOOL_LIMIT` and `EXECUTION_MONITOR_TOTAL_TOOL_LIMIT` if Adviser reviews happen too late or too often for your model and target.
+- Enable planning with `AGENT_PLANNING_STEP_ENABLED=true` for complex pentest flows so specialist agents receive a bounded execution plan.
+- Review hard tool-call limits with `MAX_GENERAL_AGENT_TOOL_CALLS` and `MAX_LIMITED_AGENT_TOOL_CALLS`; these remain the final guardrails for runaway executions.
+
+Also narrow the task prompt. Instead of only `Perform penetration testing on the host 192.168.136.136`, include the authorized target, scope, expected output, and stopping criteria, for example: enumerate exposed services, try likely public exploits, avoid repeating failed commands more than twice, and stop with a concise findings report if no path is found.
+
+Use PentAGI flow logs, Docker logs, and provider or vLLM logs together when diagnosing a long run:
+
+- Repeated identical shell/browser actions point toward tool-loop behavior.
+- Long gaps between actions point toward slow model generation or provider latency.
+- Frequent malformed tool calls point toward provider/tool-call parser compatibility.
+- Varied but slow exploration can simply mean the target is complex or the prompt is too broad.
+
+Qwen3.5-27B-FP8 can run useful local flows, but complex autonomous pentests may still need execution monitoring, task planning, tighter prompts, and careful log review.
+
 ### Issue: "Unknown architecture 'qwen3_5'"
 
 **Cause**: Using stable vLLM release instead of nightly.


### PR DESCRIPTION
## Summary
- Adds a Qwen3.5-27B-FP8 troubleshooting note for automation flows that run for hours or repeat commands.
- Points users to existing execution monitoring, planning, and tool-call limit controls before assuming a runtime bug.
- Adds a cross-reference from the advanced flow execution docs to the Qwen guide.

## Problem
Issue #344 reports a Tomato VulnHub penetration test running for more than 5 hours with Qwen3.5-27b through an OpenAI-compatible custom provider. The flow appeared to repeat commands and make slow progress. PentAGI already documents execution monitoring, task planning, reflector recovery, and hard tool-call limits, but the Qwen guide did not connect those controls to long-running local/custom model flows.

Refs #344

## Solution
- Document how to diagnose long-running or looping Qwen/custom-model flows using existing controls: `EXECUTION_MONITOR_ENABLED`, `EXECUTION_MONITOR_SAME_TOOL_LIMIT`, `EXECUTION_MONITOR_TOTAL_TOOL_LIMIT`, `AGENT_PLANNING_STEP_ENABLED`, `MAX_GENERAL_AGENT_TOOL_CALLS`, and `MAX_LIMITED_AGENT_TOOL_CALLS`.
- Recommend bounded prompts with target, scope, expected output, and stopping criteria instead of broad requests such as only performing penetration testing on a host.
- Tell operators to compare PentAGI flow logs, Docker logs, and provider/vLLM logs to separate model weakness, tool loops, target complexity, and provider/tool-call issues.

## User Impact
Users running local or custom Qwen3.5-27B-style models get a practical first troubleshooting path without changing PentAGI runtime behavior, defaults, dependencies, or generated artifacts.

## Test Plan
- `git fetch upstream main`
- `git diff --check upstream/main...HEAD`
- `git diff --name-only upstream/main...HEAD`
- Verified all referenced env vars exist in `.env.example` and `backend/docs/config.md`.
- No automated tests were run because this is a docs-only change.