### PR TITLE
Add PentAGI Kali tool setup runbook

### DIFF
--- a/.agents/skills/pentagi-kali-tools/SKILL.md
+++ b/.agents/skills/pentagi-kali-tools/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pentagi-kali-tools
+description: Verify and operate the local PentAGI Kali worker toolchain. Use when checking PentAGI/Kali tools, Metasploit DB setup, ProjectDiscovery paths, Graphiti/SearXNG/Langfuse/scraper reachability, Mullvad egress, or when looking for runbooks/examples for the Kali tools in /Users/rep/Documents/ROTMG/pentagi.
+---
+
+# PentAGI Kali Tools
+
+## Quick Start
+
+Default worker: `pentagi-terminal-9`.
+
+Run the verifier:
+
+```bash
+scripts/verify_worker.sh pentagi-terminal-9
+```
+
+It runs the existing worker smoke test, the tooling inventory verifier, Metasploit DB status, service reachability, and flow count. Do not print provider keys or `.env` values.
+
+## Workflow
+
+1. Identify the active worker with `docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}'`.
+2. Verify the worker before changing anything:
+   - `/tmp/pentagi_tool_smoke.py` should report `44 pass / 0 fail`.
+   - `/usr/local/bin/verify_pentagi_tooling.sh` should report no missing tools.
+   - `msfconsole -q -x "db_status; workspace; exit"` should show PostgreSQL connected.
+3. Check path-sensitive tools resolve through `/usr/local/bin`: `nuclei`, `subfinder`, `dnsx`, `ffuf`, `httpx`, `naabu`, `katana`, `alterx`, `responder`.
+4. If the active worker is patched, rebuild `local/kali-pentest:latest` from `/Users/rep/Documents/ROTMG/pentagi/Dockerfile.kali` so the next worker inherits the fix.
+5. Keep only one PentAGI flow running unless the user explicitly asks otherwise.
+
+## References
+
+Read `references/tool-runbooks.md` when the user asks where runbooks, examples, or tool docs live.
+
+Useful local artifacts:
+
+- Worker smoke report: `/work/rotmg-reports/pentagi-tool-smoke-current.json`
+- Inventory report: `/work/rotmg-reports/pentagi-tooling-verification-current.json`
+- Custom image: `/Users/rep/Documents/ROTMG/pentagi/Dockerfile.kali`
+- Metasploit setup helper: `/Users/rep/Documents/ROTMG/pentagi/setup_metasploit_db.sh`

--- a/.agents/skills/pentagi-kali-tools/agents/openai.yaml
+++ b/.agents/skills/pentagi-kali-tools/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PentAGI Kali Tools"
+  short_description: "Verify and operate the PentAGI Kali worker toolchain."
+  default_prompt: "Use the PentAGI Kali tools runbook to verify the worker, inspect tool setup, and run safe smoke checks."

--- a/.agents/skills/pentagi-kali-tools/references/tool-runbooks.md
+++ b/.agents/skills/pentagi-kali-tools/references/tool-runbooks.md
@@ -1,0 +1,50 @@
+# Tool Runbooks
+
+There is no curated custom runbook set yet beyond this skill. Use these existing sources first.
+
+## PentAGI Local Docs
+
+- `/Users/rep/Documents/ROTMG/pentagi/examples/guides/`
+- `/Users/rep/Documents/ROTMG/pentagi/examples/prompts/`
+- `/Users/rep/Documents/ROTMG/pentagi/backend/docs/`
+
+Useful files:
+
+- `examples/guides/worker_node.md`
+- `examples/guides/openvas-custom-image.md`
+- `examples/prompts/base_web_pentest.md`
+- `examples/prompts/offline_rotmg_static_review.md`
+- `backend/docs/flow_execution.md`
+- `backend/docs/docker.md`
+- `backend/docs/observability.md`
+- `backend/docs/prompt_engineering_pentagi.md`
+
+## Kali Worker Vendor Docs
+
+Inside the worker container:
+
+- Metasploit guides: `/usr/share/metasploit-framework/docs/metasploit-framework.wiki/`
+- Metasploit DB example: `/usr/share/metasploit-framework/config/database.yml.example`
+- ZAP getting started: `/root/.ZAP/lang/ZAPGettingStartedGuide-2.17.pdf`
+- sqlmap docs/examples: `/usr/share/doc/sqlmap/`
+- hashcat docs/examples: `/usr/share/doc/hashcat/`, `/usr/share/doc/hashcat-data/examples/`
+- john examples: `/usr/share/doc/john/EXAMPLES.gz`
+- impacket examples: `/usr/share/doc/python3-impacket/examples/`
+- socat examples: `/usr/share/doc/socat/EXAMPLES.gz`
+
+## Verified Tool Groups
+
+- ProjectDiscovery: `nuclei`, `subfinder`, `httpx`, `naabu`, `katana`, `dnsx`, `alterx`
+- Metasploit: `msfconsole`, `msfvenom`, `msfdb`, `msfrpcd`
+- Network/AD: `nmap`, `masscan`, `netexec`, `crackmapexec`, `enum4linux`, `impacket-scripts`, `bloodhound.py`, `ldapdomaindump`, `responder`
+- Web: `nikto`, `gobuster`, `dirb`, `dirsearch`, `ffuf`, `zap.sh`, `wpscan`, `sqlmap`
+- Credentials: `hydra`, `john`, `hashcat`
+- Capture/pivot: `tcpdump`, `tshark`, `socat`, `nc`
+- OSINT/utilities: `searchsploit`, `iptables`, `curl`, `jq`
+
+## Safety Defaults
+
+- Prefer `--help`, `-version`, config, and service health checks.
+- Do not run target scans unless the user provides scope.
+- Do not print `.env`, provider keys, tokens, cookies, hashes, or raw target secrets.
+- Keep one flow active unless explicitly asked to start another.

--- a/.agents/skills/pentagi-kali-tools/scripts/verify_worker.sh
+++ b/.agents/skills/pentagi-kali-tools/scripts/verify_worker.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+worker="${1:-pentagi-terminal-9}"
+
+docker exec "$worker" sh -lc '
+set -eu
+python3 /tmp/pentagi_tool_smoke.py > /work/rotmg-reports/pentagi-tool-smoke-current.json
+/usr/local/bin/verify_pentagi_tooling.sh > /work/rotmg-reports/pentagi-tooling-verification-current.json
+python3 - <<PY
+import json
+smoke="/work/rotmg-reports/pentagi-tool-smoke-current.json"
+verify="/work/rotmg-reports/pentagi-tooling-verification-current.json"
+s=json.load(open(smoke))
+v=json.load(open(verify))
+missing=[c["category"]+":"+t["name"] for c in v.get("categories",[]) for t in c.get("tools",[]) if t.get("status")=="missing"]
+print("smoke="+smoke)
+print("pass="+str(s["summary"]["pass"]))
+print("fail="+str(s["summary"]["fail"]))
+print("inventory="+verify)
+print("missing="+("none" if not missing else ",".join(missing)))
+print("mullvad_exit_ip="+str(v.get("mullvad",{}).get("mullvad_exit_ip")))
+PY
+msfconsole -q -x "db_status; workspace; exit"
+for url in http://graphiti:8000/healthcheck http://searxng:8080/ http://langfuse-web:3000/api/public/health https://scraper/; do
+  printf "%s=" "$url"
+  curl -ksS --max-time 8 "$url" | head -c 100
+  echo
+done
+'
+
+docker exec pgvector sh -lc 'PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atc "select status,count(*) from flows where deleted_at is null group by status order by status; select id,title,status,model_provider_name,model from flows where deleted_at is null order by id desc limit 3;"'

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@ node_modules
 .cursorignore
 .cursor/
 .agents/
+!.agents/
+.agents/*
+!.agents/skills/
+.agents/skills/*
+!.agents/skills/pentagi-kali-tools/
+!.agents/skills/pentagi-kali-tools/**
 skills-lock.json
 
 build/*
@@ -34,4 +40,3 @@ data/*
 
 # OS
 Thumbs.db
-

--- a/Dockerfile.kali
+++ b/Dockerfile.kali
@@ -1,0 +1,58 @@
+# Custom Kali pentest image with the worker firewall tools.
+# Build: docker build -f Dockerfile.kali -t local/kali-pentest:latest .
+# Use:   DOCKER_DEFAULT_IMAGE_FOR_PENTEST=local/kali-pentest:latest in .env
+
+FROM vxcontrol/kali-linux:latest
+
+COPY verify_pentagi_tooling.sh /usr/local/bin/verify_pentagi_tooling.sh
+COPY impacket-scripts /usr/local/bin/impacket-scripts
+
+# Keep this layer small. Full Kali upgrades are large enough to exhaust the
+# local Colima disk during iterative worker rebuilds.
+RUN apt-get update && \
+    chmod +x /usr/local/bin/verify_pentagi_tooling.sh && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iptables python3-netifaces && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl unzip; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64|arm64) pd_arch="$arch" ;; \
+      *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    tmp="$(mktemp -d)"; \
+    for spec in \
+      "naabu 2.6.1" \
+      "katana 1.6.1" \
+      "alterx 0.1.0" \
+      "httpx 1.9.0"; \
+    do \
+      set -- $spec; \
+      name="$1"; version="$2"; \
+      url="https://github.com/projectdiscovery/$name/releases/download/v$version/${name}_${version}_linux_${pd_arch}.zip"; \
+      curl -fsSL "$url" -o "$tmp/$name.zip"; \
+      unzip -q "$tmp/$name.zip" -d "$tmp/$name"; \
+      install -m 0755 "$(find "$tmp/$name" -type f -name "$name" | head -n 1)" "/usr/local/bin/$name"; \
+    done; \
+    mkdir -p /root/go/bin; \
+    for name in naabu katana alterx httpx; do \
+      ln -sf "/usr/local/bin/$name" "/root/go/bin/$name"; \
+    done; \
+    rm -rf "$tmp"; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    chmod +x /usr/local/bin/impacket-scripts; \
+    ln -sf /usr/bin/bloodhound-python /usr/local/bin/bloodhound.py; \
+    for name in nuclei subfinder dnsx ffuf; do \
+      if [ -x "/root/go/bin/$name" ]; then ln -sf "/root/go/bin/$name" "/usr/local/bin/$name"; fi; \
+    done; \
+    printf '%s\n' '#!/usr/bin/env sh' 'cd /usr/share/responder' 'exec /usr/bin/python3 ./Responder.py "$@"' > /usr/local/bin/responder; \
+    chmod +x /usr/local/bin/responder
+
+# nuclei v3.9+ needs Go 1.25; apt provides v3.8.0; update templates only
+# ponytail: go install skipped — build containers can't reach github.com via git; apt upgrade covers the rest
+RUN nuclei -update-templates -disable-update-check 2>/dev/null || true

--- a/impacket-scripts
+++ b/impacket-scripts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+if [ $# -eq 0 ]; then
+  echo 'Usage: impacket-scripts <script-name> [args...]'
+  echo 'Available scripts:'
+  ls /usr/bin/impacket-* 2>/dev/null | sed 's|/usr/bin/impacket-||'
+  exit 1
+fi
+script=$1
+shift
+exec /usr/bin/impacket-$script "$@"

--- a/mimo.provider.yml
+++ b/mimo.provider.yml
@@ -1,0 +1,91 @@
+simple:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 0.6
+  top_p: 0.95
+  n: 1
+  max_tokens: 8192
+
+simple_json:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 0.6
+  top_p: 0.95
+  n: 1
+  max_tokens: 4096
+  json: true
+
+primary_agent:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 16384
+
+A:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 16384
+
+generator:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 32768
+
+refiner:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 32768
+
+adviser:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 8192
+
+reflector:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 0.6
+  top_p: 0.95
+  n: 1
+  max_tokens: 4096
+
+searcher:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 0.6
+  top_p: 0.95
+  n: 1
+  max_tokens: 4096
+
+enricher:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 0.6
+  top_p: 0.95
+  n: 1
+  max_tokens: 4096
+
+coder:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 20480
+
+installer:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 16384
+
+pentester:
+  model: mimo-v2.5-pro-ultraspeed
+  temperature: 1.0
+  top_p: 0.95
+  n: 1
+  max_tokens: 16384

--- a/setup_metasploit_db.sh
+++ b/setup_metasploit_db.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+worker="${1:-pentagi-terminal-9}"
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+docker exec pgvector sh -lc '
+set -eu
+pw="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 40)"
+
+if [ "$(psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atc "select 1 from pg_roles where rolname = '\''metasploit'\''")" != "1" ]; then
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE ROLE metasploit LOGIN PASSWORD '\''$pw'\''" >/dev/null
+else
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "ALTER ROLE metasploit LOGIN PASSWORD '\''$pw'\''" >/dev/null
+fi
+
+if [ "$(psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atc "select 1 from pg_database where datname = '\''metasploit'\''")" != "1" ]; then
+  createdb -U "$POSTGRES_USER" -O metasploit metasploit
+fi
+
+psql -U "$POSTGRES_USER" -d metasploit -c "ALTER DATABASE metasploit OWNER TO metasploit" >/dev/null
+psql -U "$POSTGRES_USER" -d metasploit -c "GRANT ALL PRIVILEGES ON DATABASE metasploit TO metasploit" >/dev/null
+
+umask 077
+cat > /tmp/metasploit_database.yml <<EOF
+production:
+  adapter: postgresql
+  database: metasploit
+  username: metasploit
+  password: $pw
+  host: pgvector
+  port: 5432
+  pool: 75
+  timeout: 5
+EOF
+'
+
+docker cp pgvector:/tmp/metasploit_database.yml "$tmp"
+docker exec "$worker" sh -lc 'mkdir -p /root/.msf4 && chmod 700 /root/.msf4'
+docker cp "$tmp" "$worker":/root/.msf4/database.yml
+docker exec "$worker" sh -lc 'chmod 600 /root/.msf4/database.yml'
+docker exec pgvector rm -f /tmp/metasploit_database.yml
+
+docker exec "$worker" sh -lc 'msfconsole -q -x "db_status; exit"'

--- a/verify_pentagi_tooling.sh
+++ b/verify_pentagi_tooling.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FIX_MODE=false
+OUTPUT_FILE="/work/rotmg-reports/pentagi-tooling-verification.json"
+
+for arg in "$@"; do
+    case "$arg" in
+        --fix) FIX_MODE=true ;;
+        *) OUTPUT_FILE="$arg" ;;
+    esac
+done
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+declare -a PROJECT_DISCOVERY=(nuclei subfinder httpx naabu katana dnsx alterx)
+declare -a METASPLOIT=(msfconsole msfvenom msfdb msfrpcd)
+declare -a NETWORK=(nmap masscan netexec crackmapexec enum4linux impacket-scripts bloodhound.py ldapdomaindump responder)
+declare -a WEB=(nikto gobuster dirb dirsearch ffuf zaproxy wpscan sqlmap)
+declare -a CREDS=(hydra john hashcat)
+declare -a CAPTURE=(tcpdump tshark socat netcat-openbsd netcat-traditional)
+declare -a OSINT=(searchsploit)
+
+ensure_on_path() {
+    local target="$1"
+    local link_name="${2:-$1}"
+    if [[ -x "$target" && ! -e "/usr/local/bin/$link_name" ]]; then
+        ln -sf "$target" "/usr/local/bin/$link_name" 2>/dev/null || true
+    fi
+}
+
+fix_tool() {
+    local name="$1"
+    case "$name" in
+        impacket-scripts)
+            cat > /usr/local/bin/impacket-scripts <<'EOF'
+#!/usr/bin/env bash
+if [ $# -eq 0 ]; then
+  echo 'Usage: impacket-scripts <script-name> [args...]'
+  echo 'Available scripts:'
+  ls /usr/bin/impacket-* 2>/dev/null | sed 's|/usr/bin/impacket-||'
+  exit 1
+fi
+script=$1
+shift
+exec /usr/bin/impacket-$script "$@"
+EOF
+            chmod +x /usr/local/bin/impacket-scripts
+            ;;
+        bloodhound.py)
+            python3 -m pip install bloodhound 2>/dev/null || true
+            rm -f /usr/local/bin/bloodhound.py
+            cat > /usr/local/bin/bloodhound.py <<'EOF'
+#!/usr/bin/env python3
+import subprocess
+import sys
+sys.exit(subprocess.call([sys.executable, "-m", "bloodhound"] + sys.argv[1:]))
+EOF
+            chmod +x /usr/local/bin/bloodhound.py
+            ;;
+        netcat-openbsd)
+            apt-get update -qq 2>/dev/null && apt-get install -y -qq netcat-openbsd 2>/dev/null || true
+            ensure_on_path /usr/bin/nc netcat-openbsd
+            ;;
+        netcat-traditional)
+            apt-get update -qq 2>/dev/null && apt-get install -y -qq netcat-traditional 2>/dev/null || true
+            ensure_on_path /usr/bin/nc.traditional netcat-traditional 2>/dev/null || ensure_on_path /usr/bin/nc netcat-traditional
+            ;;
+    esac
+}
+
+check_tool() {
+    local name="$1"
+    local path
+    path=$(command -v "$name" 2>/dev/null || true)
+    if [[ -n "$path" && -x "$path" ]]; then
+        printf '{"name":"%s","path":"%s","status":"available"}' "$name" "$path"
+        return
+    fi
+
+    if [[ "$FIX_MODE" == true ]]; then
+        fix_tool "$name" >/dev/null 2>&1 || true
+        path=$(command -v "$name" 2>/dev/null || true)
+        if [[ -n "$path" && -x "$path" ]]; then
+            printf '{"name":"%s","path":"%s","status":"available"}' "$name" "$path"
+            return
+        fi
+    fi
+
+    if dpkg -s "$name" >/dev/null 2>&1; then
+        printf '{"name":"%s","path":null,"status":"installed_package"}' "$name"
+    else
+        printf '{"name":"%s","path":null,"status":"missing"}' "$name"
+    fi
+}
+
+check_category() {
+    local category="$1"
+    shift
+    local -a tools=("$@")
+    local results=()
+    for t in "${tools[@]}"; do
+        results+=("$(check_tool "$t")")
+    done
+    local joined
+    joined=$(IFS=,; printf '%s' "${results[*]}")
+    printf '{"category":"%s","tools":[%s]}' "$category" "$joined"
+}
+
+CATEGORIES=()
+CATEGORIES+=("$(check_category "projectdiscovery" "${PROJECT_DISCOVERY[@]}")")
+CATEGORIES+=("$(check_category "metasploit" "${METASPLOIT[@]}")")
+CATEGORIES+=("$(check_category "network" "${NETWORK[@]}")")
+CATEGORIES+=("$(check_category "web" "${WEB[@]}")")
+CATEGORIES+=("$(check_category "credentials" "${CREDS[@]}")")
+CATEGORIES+=("$(check_category "capture_pivot" "${CAPTURE[@]}")")
+CATEGORIES+=("$(check_category "osint" "${OSINT[@]}")")
+CATEGORIES_JOINED=$(IFS=,; printf '%s' "${CATEGORIES[*]}")
+
+MULLVAD_STATUS=$(curl -sS --max-time 10 https://am.i.mullvad.net/json 2>/dev/null || echo '{}')
+
+JSON=$(cat <<EOF
+{
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "hostname": "$(hostname)",
+  "container_image": "${PENTAGI_DOCKER_IMAGE:-unknown}",
+  "categories": [$CATEGORIES_JOINED],
+  "mullvad": $MULLVAD_STATUS
+}
+EOF
+)
+
+printf '%s\n' "$JSON" | tee "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- add a custom Kali worker image setup for verified PentAGI tools
- add Metasploit DB setup and tool verification helpers
- add a Codex skill/runbook for PentAGI Kali tool checks

## Verification
- /Users/rep/Documents/ROTMG/pentagi/.agents/skills/pentagi-kali-tools/scripts/verify_worker.sh pentagi-terminal-9
- worker smoke: 44 pass / 0 fail
- Metasploit DB connected
- Mullvad exit check true
