### PR TITLE
fix(cast): delete pruned tool-call parts in reverse to avoid index shift

### DIFF
--- a/backend/pkg/cast/chain_ast.go
+++ b/backend/pkg/cast/chain_ast.go
@@ -453,7 +453,11 @@ func NewBodyPair(aiMsg *llms.MessageContent, toolMsgs []*llms.MessageContent) *B
 				break
 			}
 		}
-		for _, id := range partsToDelete {
+		// Delete in reverse so each removal does not shift the indices of the
+		// entries still pending deletion (a forward loop with the pre-collected
+		// ascending indices would delete the wrong elements once there are 2+).
+		for i := len(partsToDelete) - 1; i >= 0; i-- {
+			id := partsToDelete[i]
 			aiMsg.Parts = append(aiMsg.Parts[:id], aiMsg.Parts[id+1:]...)
 		}
 	}

--- a/backend/pkg/cast/newbodypair_reg_test.go
+++ b/backend/pkg/cast/newbodypair_reg_test.go
@@ -1,0 +1,28 @@
+package cast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vxcontrol/langchaingo/llms"
+)
+
+func TestNewBodyPair_DropsMultipleNilFunctionCallToolCalls(t *testing.T) {
+	aiMsg := &llms.MessageContent{
+		Role: llms.ChatMessageTypeAI,
+		Parts: []llms.ContentPart{
+			llms.ToolCall{ID: "a", Type: "function", FunctionCall: nil},
+			llms.ToolCall{ID: "b", Type: "function", FunctionCall: nil},
+			llms.TextContent{Text: "keep me"},
+		},
+	}
+
+	NewBodyPair(aiMsg, nil)
+
+	assert.Len(t, aiMsg.Parts, 1, "both nil-FunctionCall tool calls should be removed, text kept")
+	if assert.Len(t, aiMsg.Parts, 1) {
+		txt, ok := aiMsg.Parts[0].(llms.TextContent)
+		assert.True(t, ok, "surviving part should be the TextContent, got %T", aiMsg.Parts[0])
+		assert.Equal(t, "keep me", txt.Text)
+	}
+}


### PR DESCRIPTION
## Problem

`NewBodyPair` (`backend/pkg/cast/chain_ast.go`) prunes `ToolCall` parts that have a `nil` `FunctionCall` from an AI message. It first collects their indices into `partsToDelete` (ascending), then deletes them in a forward loop:

```go
for _, id := range partsToDelete {
    aiMsg.Parts = append(aiMsg.Parts[:id], aiMsg.Parts[id+1:]...)
}
```

Each `append`-based deletion shifts every later element left by one, but the loop keeps using the original, now-stale indices. With **two or more** collected indices, the second (and later) deletions remove the wrong elements.

### Concrete failure

Input parts `[ToolCall{FC:nil}, ToolCall{FC:nil}, TextContent{"keep me"}]` (two leading invalid tool calls, then real text):

- Expected after pruning: `["keep me"]`
- Actual: `[ToolCall{FC:nil}]` — the legitimate text is dropped and an **invalid** nil-`FunctionCall` tool call survives into the message chain, feeding malformed messages to downstream summarization / LLM code.

(The scan `continue`s over nil-FC tool calls and only `break`s on a *valid* tool call, so 2+ leading nil-FC tool calls are collected — the trigger.)

## Fix

Delete the collected indices in reverse, so removing a later element never invalidates the indices still pending:

```go
for i := len(partsToDelete) - 1; i >= 0; i-- {
    id := partsToDelete[i]
    aiMsg.Parts = append(aiMsg.Parts[:id], aiMsg.Parts[id+1:]...)
}
```

## Tests

Added `TestNewBodyPair_DropsMultipleNilFunctionCallToolCalls` in `backend/pkg/cast/newbodypair_reg_test.go`.

- Before the fix it fails (surviving part is a `ToolCall`, text lost).
- After the fix it passes.

`go test ./pkg/cast/ ./pkg/csum/` passes (no regressions) and `go vet ./pkg/cast/` is clean.
