### PR TITLE
fix(flows): allow pending trace IDs in flow responses

### DIFF
--- a/backend/pkg/server/docs/docs.go
+++ b/backend/pkg/server/docs/docs.go
@@ -8436,7 +8436,6 @@ const docTemplate = `{
                 "status",
                 "title",
                 "tool_call_id_template",
-                "trace_id",
                 "user_id"
             ],
             "properties": {
@@ -8590,7 +8589,6 @@ const docTemplate = `{
                 "tasks",
                 "title",
                 "tool_call_id_template",
-                "trace_id",
                 "user_id"
             ],
             "properties": {

--- a/backend/pkg/server/docs/swagger.json
+++ b/backend/pkg/server/docs/swagger.json
@@ -8428,7 +8428,6 @@
                 "status",
                 "title",
                 "tool_call_id_template",
-                "trace_id",
                 "user_id"
             ],
             "properties": {
@@ -8582,7 +8581,6 @@
                 "tasks",
                 "title",
                 "tool_call_id_template",
-                "trace_id",
                 "user_id"
             ],
             "properties": {

--- a/backend/pkg/server/docs/swagger.yaml
+++ b/backend/pkg/server/docs/swagger.yaml
@@ -633,7 +633,6 @@ definitions:
     - status
     - title
     - tool_call_id_template
-    - trace_id
     - user_id
     type: object
   models.FlowExecutionStats:
@@ -746,7 +745,6 @@ definitions:
     - tasks
     - title
     - tool_call_id_template
-    - trace_id
     - user_id
     type: object
   models.FlowUsageResponse:

--- a/backend/pkg/server/models/flows.go
+++ b/backend/pkg/server/models/flows.go
@@ -56,7 +56,7 @@ type Flow struct {
 	Language           string           `form:"language" json:"language" validate:"max=70,required" gorm:"type:TEXT;NOT NULL"`
 	Functions          *tools.Functions `form:"functions,omitempty" json:"functions,omitempty" validate:"omitempty,valid" gorm:"type:JSON;NOT NULL;default:'{}'"`
 	ToolCallIDTemplate string           `form:"tool_call_id_template" json:"tool_call_id_template" validate:"max=70,required" gorm:"type:TEXT;NOT NULL"`
-	TraceID            *string          `form:"trace_id" json:"trace_id" validate:"max=70,required" gorm:"type:TEXT;NOT NULL"`
+	TraceID            *string          `form:"trace_id" json:"trace_id" validate:"omitempty,max=70" gorm:"type:TEXT"`
 	UserID             uint64           `form:"user_id" json:"user_id" validate:"min=0,numeric,required" gorm:"type:BIGINT;NOT NULL"`
 	CreatedAt          time.Time        `form:"created_at,omitempty" json:"created_at,omitempty" validate:"omitempty" gorm:"type:TIMESTAMPTZ;default:CURRENT_TIMESTAMP"`
 	UpdatedAt          time.Time        `form:"updated_at,omitempty" json:"updated_at,omitempty" validate:"omitempty" gorm:"type:TIMESTAMPTZ;default:CURRENT_TIMESTAMP"`

--- a/backend/pkg/server/models/flows_test.go
+++ b/backend/pkg/server/models/flows_test.go
@@ -374,6 +374,21 @@ func TestFlowValid(t *testing.T) {
 		assert.NoError(t, validFlow.Valid())
 	})
 
+	t.Run("valid flow while trace id is pending", func(t *testing.T) {
+		t.Parallel()
+		f := validFlow
+		f.TraceID = nil
+		assert.NoError(t, f.Valid())
+	})
+
+	t.Run("trace id exceeds maximum length", func(t *testing.T) {
+		t.Parallel()
+		traceID := "trace-id-that-is-longer-than-the-supported-seventy-character-validation-limit-123"
+		f := validFlow
+		f.TraceID = &traceID
+		assert.Error(t, f.Valid())
+	})
+
 	t.Run("missing title", func(t *testing.T) {
 		t.Parallel()
 		f := validFlow

--- a/backend/pkg/server/services/flows_test.go
+++ b/backend/pkg/server/services/flows_test.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"pentagi/pkg/server/models"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFlowsAllowsPendingTraceID(t *testing.T) {
+	db := setupFlowFileServiceTestDB(t)
+	require.NoError(t, db.Exec(`
+		INSERT INTO flows (
+			id, user_id, model, model_provider_name, model_provider_type,
+			tool_call_id_template, trace_id
+		) VALUES (1, 42, 'gpt', 'openai', 'openai', 'tcid', NULL)
+	`).Error)
+
+	c, w := newFlowFileTestContext(
+		http.MethodGet,
+		"/flows/?page=1&pageSize=5&type=init",
+		nil,
+		[]string{"flows.view"},
+		42,
+		0,
+	)
+
+	NewFlowService(db, nil, nil, nil).GetFlows(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			Flows []models.Flow `json:"flows"`
+			Total uint64        `json:"total"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "success", resp.Status)
+	require.Equal(t, uint64(1), resp.Data.Total)
+	require.Len(t, resp.Data.Flows, 1)
+	require.Nil(t, resp.Data.Flows[0].TraceID)
+}


### PR DESCRIPTION
### Description of the Change

#### Problem

The database schema allows `flows.trace_id` to be `NULL`, which can occur while observability initialization is still pending. However, the server-side `Flow` model treated `trace_id` as required and declared the column as `NOT NULL`.

As a result, valid flow records with a pending trace ID could fail model validation when returned by endpoints such as `GET /flows`.

#### Solution

This change aligns the server model with the existing nullable database schema:

- Makes `Flow.TraceID` optional while retaining the 70-character maximum length validation.
- Removes the incorrect `NOT NULL` GORM constraint.
- Updates the generated Swagger documentation so `trace_id` is no longer required.
- Adds model tests covering missing and oversized trace IDs.
- Adds a service-level regression test confirming that `GET /flows` returns flows with pending trace IDs successfully.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test update
- [ ] 🛡️ Security update

### Areas Affected

- [x] Core Services (Frontend UI/Backend API)
- [ ] AI Agents (Researcher/Developer/Executor)
- [ ] Security Tools Integration
- [ ] Memory System (Vector Store/Knowledge Base)
- [ ] Monitoring Stack (Grafana/OpenTelemetry)
- [ ] Analytics Platform (Langfuse)
- [ ] External Integrations (LLM/Search APIs)
- [x] Documentation
- [ ] Infrastructure/DevOps

### Testing and Verification

#### Test Configuration

```yaml
PentAGI Version: 1154a81
Docker Version: Not used
Host OS: Windows
LLM Provider: Not required
Enabled Features: []
```

#### Test Steps

1. Run the flow model validation tests:

   ```bash
   cd backend
   go test ./pkg/server/models -run '^TestFlowValid$' -count=1
   ```

2. Run the flow service regression test:

   ```bash
   go test ./pkg/server/services -run '^TestGetFlowsAllowsPendingTraceID$' -count=1
   ```

3. Run static analysis for the affected packages:

   ```bash
   go vet ./pkg/server/models ./pkg/server/services
   ```

#### Test Results

All tests and static analysis relevant to this change passed:

```text
ok   pentagi/pkg/server/models
ok   pentagi/pkg/server/services
go vet completed successfully
```

The complete services test suite has unrelated Windows-specific failures involving path separators and filename handling. The new regression test passes independently.

### Security Considerations

This change does not modify authentication, authorization, permissions, or sensitive-data handling.

Allowing a temporarily missing trace ID does not bypass any access controls. The existing maximum-length validation remains in place when a trace ID is provided.

### Performance Impact

No measurable performance impact is expected. The change only adjusts validation and schema metadata for one optional field and does not add database queries or processing overhead.

### Documentation Updates

- [ ] README.md updates
- [x] API documentation updates
- [ ] Configuration documentation updates
- [ ] GraphQL schema updates
- [ ] Other

The generated Swagger JSON, YAML, and Go documentation have been updated to represent `trace_id` as optional.

### Deployment Notes

No special deployment steps, environment variables, configuration changes, or database migrations are required.

The existing database migration already defines `flows.trace_id` as nullable.

### Checklist

#### Code Quality

- [x] My code follows the project's coding standards
- [x] I have added/updated necessary documentation
- [x] I have added tests to cover my changes
- [ ] All new and existing tests pass
- [x] I have run `go fmt` and `go vet` (for Go code)
- [ ] I have run `pnpm run lint` (for TypeScript/JavaScript code)

#### Security

- [x] I have considered security implications
- [x] Changes maintain or improve the security model
- [x] Sensitive information has been properly handled

#### Compatibility

- [x] Changes are backward compatible
- [ ] Breaking changes are clearly marked and documented
- [ ] Dependencies are properly updated

#### Documentation

- [x] Documentation is clear and complete
- [ ] Comments are added for non-obvious code
- [x] API changes are documented

### Additional Notes

The `flows.trace_id` database column was already nullable. This change corrects the server model and API schema so they accurately reflect the existing database behavior.