### PR TITLE
fix(docker): rebuild flow primary container when it is gone from the daemon

### DIFF
--- a/backend/pkg/docker/client.go
+++ b/backend/pkg/docker/client.go
@@ -600,7 +600,11 @@ func (dc *dockerClient) Cleanup(ctx context.Context) error {
 func (dc *dockerClient) IsContainerRunning(ctx context.Context, containerID string) (bool, error) {
 	inspection, err := dc.client.ContainerInspect(ctx, containerID)
 	if err != nil {
-		return false, fmt.Errorf("container inspection failed: %w", err)
+		if !client.IsErrNotFound(err) {
+			return false, fmt.Errorf("container inspection failed: %w", err)
+		}
+		// a removed container is missing, not an inspection failure
+		return false, nil
 	}
 
 	// Check both Running state and health status if available

--- a/backend/pkg/docker/client_test.go
+++ b/backend/pkg/docker/client_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 )
 
 func TestStatContainerEntries_AllSucceed(t *testing.T) {
@@ -259,4 +260,80 @@ func failNames(failures []statFailure) map[string]bool {
 		m[f.name] = true
 	}
 	return m
+}
+
+const probeImage = "alpine:3.20"
+
+// newDaemonClient binds a client to the local daemon, skipping the test when
+// none is reachable.
+func newDaemonClient(t *testing.T) *dockerClient {
+	t.Helper()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		t.Skipf("docker daemon unavailable: %v", err)
+	}
+
+	ctx := context.Background()
+	cli.NegotiateAPIVersion(ctx)
+	if _, err := cli.Ping(ctx); err != nil {
+		t.Skipf("docker daemon unavailable: %v", err)
+	}
+
+	return &dockerClient{client: cli}
+}
+
+// A flow keeps the id of its primary container in the database. When that
+// container is removed behind pentagi's back the id has to read as not running,
+// otherwise the flow can never rebuild it.
+func TestIsContainerRunningRemovedContainer(t *testing.T) {
+	dc := newDaemonClient(t)
+	ctx := context.Background()
+
+	created, err := dc.client.ContainerCreate(ctx, &container.Config{
+		Image:      probeImage,
+		Entrypoint: []string{"tail", "-f", "/dev/null"},
+	}, nil, nil, nil, "")
+	if client.IsErrNotFound(err) {
+		t.Skipf("%s is not present locally", probeImage)
+	}
+	if err != nil {
+		t.Fatalf("create probe container: %v", err)
+	}
+	t.Cleanup(func() {
+		dc.client.ContainerRemove(context.Background(), created.ID, container.RemoveOptions{Force: true})
+	})
+
+	if err := dc.client.ContainerStart(ctx, created.ID, container.StartOptions{}); err != nil {
+		t.Fatalf("start probe container: %v", err)
+	}
+
+	running, err := dc.IsContainerRunning(ctx, created.ID)
+	if err != nil || !running {
+		t.Fatalf("got running=%v err=%v, want true and no error", running, err)
+	}
+
+	if err := dc.client.ContainerRemove(ctx, created.ID, container.RemoveOptions{Force: true}); err != nil {
+		t.Fatalf("remove probe container: %v", err)
+	}
+
+	running, err = dc.IsContainerRunning(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("removed container: got error %v, want none", err)
+	}
+	if running {
+		t.Fatal("removed container reported as running")
+	}
+}
+
+func TestIsContainerRunningUnknownContainer(t *testing.T) {
+	dc := newDaemonClient(t)
+
+	running, err := dc.IsContainerRunning(context.Background(), "pentagi-container-that-does-not-exist")
+	if err != nil {
+		t.Fatalf("unknown container: got error %v, want none", err)
+	}
+	if running {
+		t.Fatal("unknown container reported as running")
+	}
 }

--- a/backend/pkg/tools/tools.go
+++ b/backend/pkg/tools/tools.go
@@ -481,18 +481,24 @@ func (fte *flowToolsExecutor) SetGraphitiClient(client *graphiti.Client) {
 
 func (fte *flowToolsExecutor) Prepare(ctx context.Context) error {
 	if cnt, err := fte.db.GetFlowPrimaryContainer(ctx, fte.flowID); err == nil {
-		switch cnt.Status {
-		case database.ContainerStatusRunning:
-			fte.primaryID = cnt.ID
-			fte.primaryLID = cnt.LocalID.String
-			if err := fte.syncMissingFiles(ctx); err != nil {
-				containerName := PrimaryTerminalName(fte.cfg.TenantPrefix(), fte.flowID)
-				return fmt.Errorf("failed to sync missing files to container '%s': %w", containerName, err)
+		// the stored status goes stale when the container is removed outside pentagi
+		if cnt.Status == database.ContainerStatusRunning {
+			containerName := PrimaryTerminalName(fte.cfg.TenantPrefix(), fte.flowID)
+			running, err := fte.docker.IsContainerRunning(ctx, cnt.LocalID.String)
+			if err != nil {
+				return fmt.Errorf("failed to inspect container '%s': %w", containerName, err)
 			}
-			return nil
-		default:
-			fte.docker.RemoveContainer(ctx, cnt.LocalID.String, cnt.ID)
+			if running {
+				fte.primaryID = cnt.ID
+				fte.primaryLID = cnt.LocalID.String
+				if err := fte.syncMissingFiles(ctx); err != nil {
+					return fmt.Errorf("failed to sync missing files to container '%s': %w", containerName, err)
+				}
+				return nil
+			}
 		}
+
+		fte.docker.RemoveContainer(ctx, cnt.LocalID.String, cnt.ID)
 	}
 
 	// Explicit capability allow-list (CapDrop: ALL below): Docker's default 14


### PR DESCRIPTION
## Summary

A flow whose primary container is removed outside PentAGI never recovers. `IsContainerRunning` now reports a missing container as not running, and `Prepare` checks with the daemon before reusing the stored container.

## Problem

A flow stores the Docker id of its primary container in `containers`. Nothing reconciles that row against the daemon, so if the container is removed outside PentAGI (`docker rm`, `docker system prune`, a host rebuild), the row keeps `status = 'running'`.

`flowToolsExecutor.Prepare` trusts that status and reuses the stored id without asking Docker, so every terminal call fails with:

```
terminal tool 'terminal' handled with error: runtime verification failed: container inspection failed: Error response from daemon: No such container: db9eae1e00b7a359059d8fcfa5d2fb1605d32abf5160697fbe6e033d77600ef0
```

Restarting PentAGI does not help, because `Prepare` re-reads the same row. The branch that rebuilds only runs for a status other than `running`, and nothing sets one once the container has gone.

The flow is not marked failed either. `terminal.go:115` returns the failure as tool output with a `nil` error, so the agent treats it as an ordinary result and keeps going, consuming tokens on a flow where no terminal or file operation can succeed.

## Solution

- `IsContainerRunning` returns `(false, nil)` for a container the daemon does not know, instead of wrapping the not-found error. `StopContainer` and `RemoveContainer` already special-case `client.IsErrNotFound` in the same file.
- `Prepare` confirms with the daemon before reusing the stored container. If it is gone, the existing remove-and-rebuild path takes over.

An unreachable daemon is still returned as an error rather than read as "container missing", so a transient failure cannot discard a healthy container.

## User Impact

Flows already broken by this recover on their next load once deployed. No migration or manual database edit.

One behaviour change worth knowing about: an operator who removes a primary container by hand to contain a misbehaving agent will now see it rebuilt on the next flow load. Stopping the flow is the supported way to halt an agent, so this is not gated behind an env var.

## Test Plan

`backend/pkg/docker/client_test.go`: start a container, remove it with `ContainerRemove(..., Force: true)`, then call `IsContainerRunning` with the same id. Before the change it returns the wrapped not-found error; after, `false` with no error, which lets `Prepare` rebuild. A second case covers an id the daemon has never seen.

Both skip when no daemon is reachable, and the first skips rather than pulling when `alpine:3.20` is absent, so neither adds a network dependency.

```
ok  	pentagi/pkg/docker	1.481s
ok  	pentagi/pkg/tools	14.431s
ok  	pentagi/pkg/controller	0.020s
```

`gofmt -l` and `go vet` are clean on the changed files. `go mod tidy` leaves `go.mod` and `go.sum` unchanged.

## Notes

A few lines below this change, `IsContainerRunning` reads `inspection.State.Running` before it checks `inspection.State != nil`. Left alone to keep the diff small.
