### PR TITLE
feat(auth): add generic OpenID Connect provider for SSO login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,17 @@ OAUTH_GOOGLE_CLIENT_SECRET=
 OAUTH_GITHUB_CLIENT_ID=
 OAUTH_GITHUB_CLIENT_SECRET=
 
+## OAuth via any OpenID Connect provider (Keycloak, Authentik, Okta, Entra ID).
+## Issuer is the URL serving /.well-known/openid-configuration, for example
+## https://keycloak.example.com/realms/pentagi
+## Register the client with the authorization code flow and the redirect URI
+## <PUBLIC_URL>/api/v1/auth/login-callback
+## Scopes are optional and default to openid,email,profile
+OAUTH_OIDC_ISSUER=
+OAUTH_OIDC_CLIENT_ID=
+OAUTH_OIDC_CLIENT_SECRET=
+OAUTH_OIDC_SCOPES=
+
 ## DuckDuckGo search engine
 DUCKDUCKGO_ENABLED=
 DUCKDUCKGO_REGION=

--- a/backend/docs/config.md
+++ b/backend/docs/config.md
@@ -598,6 +598,10 @@ These settings control authentication mechanisms, including cookie-based session
 | OAuthGoogleClientSecret | `OAUTH_GOOGLE_CLIENT_SECRET` | *(none)*      | Google OAuth client secret                             |
 | OAuthGithubClientID     | `OAUTH_GITHUB_CLIENT_ID`     | *(none)*      | GitHub OAuth client ID for authentication              |
 | OAuthGithubClientSecret | `OAUTH_GITHUB_CLIENT_SECRET` | *(none)*      | GitHub OAuth client secret                             |
+| OAuthOIDCIssuer         | `OAUTH_OIDC_ISSUER`          | *(none)*      | Issuer URL of any OpenID Connect provider, i.e. the URL serving `/.well-known/openid-configuration` |
+| OAuthOIDCClientID       | `OAUTH_OIDC_CLIENT_ID`       | *(none)*      | Client ID registered with the OpenID Connect provider  |
+| OAuthOIDCClientSecret   | `OAUTH_OIDC_CLIENT_SECRET`   | *(none)*      | Client secret registered with the OpenID Connect provider |
+| OAuthOIDCScopes         | `OAUTH_OIDC_SCOPES`          | `openid,email,profile` | Comma separated scopes requested from the provider |
 
 ### Usage Details
 
@@ -640,6 +644,34 @@ The authentication settings are used in `pkg/server/router.go` to set up authent
   OAUTH_GOOGLE_CLIENT_ID=your_google_client_id
   OAUTH_GOOGLE_CLIENT_SECRET=your_google_client_secret
   ```
+
+- **Generic OpenID Connect (SSO)**: Any OpenID Connect provider — Keycloak, Authentik, Okta,
+  Entra ID, Auth0 — is configured with three settings. PentAGI reads the provider's discovery
+  document at startup, so no endpoint URLs have to be spelled out:
+
+  ```bash
+  PUBLIC_URL=https://pentagi.example.com
+  OAUTH_OIDC_ISSUER=https://keycloak.example.com/realms/pentagi
+  OAUTH_OIDC_CLIENT_ID=pentagi
+  OAUTH_OIDC_CLIENT_SECRET=your_client_secret
+  # optional, defaults to openid,email,profile
+  OAUTH_OIDC_SCOPES=openid,email,profile
+  ```
+
+  Register the client in the identity provider with the standard authorization code flow and the
+  redirect URI `${PUBLIC_URL}/api/v1/auth/login-callback`. The provider then appears on the login
+  screen as **Continue with SSO**.
+
+  PentAGI matches the account by the `email` claim, taking it from the ID token and falling back to
+  the UserInfo endpoint when the ID token carries no email. Users whose email is unknown to PentAGI
+  are created on first login with the regular `User` role, exactly as with the Google and GitHub
+  providers — administrators are still promoted explicitly. PentAGI itself does not restrict which
+  accounts may log in, so limit access on the identity provider side (for example by binding the
+  client to a group or policy) when the provider serves more people than PentAGI should admit.
+
+  When the identity provider is unreachable at startup, discovery fails, the error is logged and the
+  server keeps running with the remaining login methods — SSO simply stays absent from the login
+  screen until the next restart.
 
 - **OAuth Provider Settings**: Used to configure authentication with Google and GitHub:
   ```go

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -183,6 +183,12 @@ type Config struct {
 	OAuthGithubClientID     string `env:"OAUTH_GITHUB_CLIENT_ID"`
 	OAuthGithubClientSecret string `env:"OAUTH_GITHUB_CLIENT_SECRET"`
 
+	// === OAuth Provider: generic OpenID Connect (Keycloak, Authentik, Okta, Entra ID) ===
+	OAuthOIDCIssuer       string   `env:"OAUTH_OIDC_ISSUER"`
+	OAuthOIDCClientID     string   `env:"OAUTH_OIDC_CLIENT_ID"`
+	OAuthOIDCClientSecret string   `env:"OAUTH_OIDC_CLIENT_SECRET"`
+	OAuthOIDCScopes       []string `env:"OAUTH_OIDC_SCOPES" envSeparator:","`
+
 	// === OAuth Callback Configuration ===
 	PublicURL string `env:"PUBLIC_URL" envDefault:""`
 

--- a/backend/pkg/server/oauth/client.go
+++ b/backend/pkg/server/oauth/client.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"golang.org/x/oauth2"
 )
@@ -16,22 +17,47 @@ type OAuthClient interface {
 	Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error)
 	RefreshToken(ctx context.Context, token string) (*oauth2.Token, error)
 	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
+	// AuthCodeOptions returns provider specific parameters for the authorization
+	// request, such as the nonce or the response mode the provider expects.
+	AuthCodeOptions(nonce string) []oauth2.AuthCodeOption
+	// CallbackSameSite reports which SameSite mode the temporary state and nonce
+	// cookies need so that they survive the provider's callback. Providers that
+	// answer with a cross-site form POST require SameSite=None.
+	CallbackSameSite() http.SameSite
+}
+
+// ClientOption customizes provider specific behaviour of an OAuth client.
+type ClientOption func(*oauthClient)
+
+// WithFormPostCallback marks the provider as answering with a cross-site form
+// POST (OpenID Connect `response_mode=form_post`) and requests an ID token
+// alongside the authorization code. Such a callback only carries the state and
+// nonce cookies when they are issued with SameSite=None.
+func WithFormPostCallback() ClientOption {
+	return func(o *oauthClient) {
+		o.formPostCallback = true
+	}
 }
 
 type oauthClient struct {
-	name          string
-	verifier      string
-	conf          *oauth2.Config
-	emailResolver OAuthEmailResolver
+	name             string
+	verifier         string
+	conf             *oauth2.Config
+	emailResolver    OAuthEmailResolver
+	formPostCallback bool
 }
 
-func NewOAuthClient(name string, conf *oauth2.Config, emailResolver OAuthEmailResolver) OAuthClient {
-	return &oauthClient{
+func NewOAuthClient(name string, conf *oauth2.Config, emailResolver OAuthEmailResolver, opts ...ClientOption) OAuthClient {
+	client := &oauthClient{
 		name:          name,
 		verifier:      oauth2.GenerateVerifier(),
 		conf:          conf,
 		emailResolver: emailResolver,
 	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client
 }
 
 func (o *oauthClient) ProviderName() string {
@@ -61,4 +87,24 @@ func (o *oauthClient) RefreshToken(ctx context.Context, token string) (*oauth2.T
 func (o *oauthClient) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
 	opts = append(opts, oauth2.S256ChallengeOption(o.verifier))
 	return o.conf.AuthCodeURL(state, opts...)
+}
+
+func (o *oauthClient) AuthCodeOptions(nonce string) []oauth2.AuthCodeOption {
+	opts := []oauth2.AuthCodeOption{
+		oauth2.SetAuthURLParam("nonce", nonce),
+	}
+	if o.formPostCallback {
+		opts = append(opts,
+			oauth2.SetAuthURLParam("response_mode", "form_post"),
+			oauth2.SetAuthURLParam("response_type", "code id_token"),
+		)
+	}
+	return opts
+}
+
+func (o *oauthClient) CallbackSameSite() http.SameSite {
+	if o.formPostCallback {
+		return http.SameSiteNoneMode
+	}
+	return http.SameSiteLaxMode
 }

--- a/backend/pkg/server/oauth/client_test.go
+++ b/backend/pkg/server/oauth/client_test.go
@@ -1,0 +1,99 @@
+package oauth
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func newTestClient(opts ...ClientOption) OAuthClient {
+	return NewOAuthClient("test", &oauth2.Config{
+		ClientID:    "client-id",
+		RedirectURL: "https://pentagi.example.com/api/v1/auth/login-callback",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://idp.example.com/auth",
+			TokenURL: "https://idp.example.com/token",
+		},
+	}, nil, opts...)
+}
+
+func TestAuthCodeOptionsDefaultsToPlainCodeFlow(t *testing.T) {
+	client := newTestClient()
+
+	authURL, err := url.Parse(client.AuthCodeURL("state", client.AuthCodeOptions("nonce-value")...))
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+
+	query := authURL.Query()
+	if got := query.Get("nonce"); got != "nonce-value" {
+		t.Errorf("nonce = %q, want %q", got, "nonce-value")
+	}
+	if got := query.Get("response_mode"); got != "" {
+		t.Errorf("response_mode = %q, want empty for a plain code flow", got)
+	}
+	if got := query.Get("response_type"); got != "code" {
+		t.Errorf("response_type = %q, want %q", got, "code")
+	}
+}
+
+func TestAuthCodeOptionsWithFormPostCallback(t *testing.T) {
+	client := newTestClient(WithFormPostCallback())
+
+	authURL, err := url.Parse(client.AuthCodeURL("state", client.AuthCodeOptions("nonce-value")...))
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+
+	query := authURL.Query()
+	if got := query.Get("response_mode"); got != "form_post" {
+		t.Errorf("response_mode = %q, want %q", got, "form_post")
+	}
+	if got := query.Get("response_type"); got != "code id_token" {
+		t.Errorf("response_type = %q, want %q", got, "code id_token")
+	}
+}
+
+func TestCallbackSameSite(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []ClientOption
+		want http.SameSite
+	}{
+		{
+			name: "get callback keeps cookies with Lax",
+			want: http.SameSiteLaxMode,
+		},
+		{
+			name: "cross-site form post requires None",
+			opts: []ClientOption{WithFormPostCallback()},
+			want: http.SameSiteNoneMode,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := newTestClient(tc.opts...).CallbackSameSite(); got != tc.want {
+				t.Errorf("CallbackSameSite() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGoogleClientUsesFormPostCallback(t *testing.T) {
+	client := NewGoogleOAuthClient("client-id", "client-secret", "https://pentagi.example.com/callback")
+
+	if got := client.CallbackSameSite(); got != http.SameSiteNoneMode {
+		t.Errorf("google CallbackSameSite() = %v, want %v", got, http.SameSiteNoneMode)
+	}
+}
+
+func TestGithubClientUsesGetCallback(t *testing.T) {
+	client := NewGithubOAuthClient("client-id", "client-secret", "https://pentagi.example.com/callback")
+
+	if got := client.CallbackSameSite(); got != http.SameSiteLaxMode {
+		t.Errorf("github CallbackSameSite() = %v, want %v", got, http.SameSiteLaxMode)
+	}
+}

--- a/backend/pkg/server/oauth/google.go
+++ b/backend/pkg/server/oauth/google.go
@@ -68,5 +68,5 @@ func NewGoogleOAuthClient(clientID, clientSecret, redirectURL string) OAuthClien
 			"openid",
 		},
 		Endpoint: google.Endpoint,
-	}, newGoogleEmailResolver(clientID))
+	}, newGoogleEmailResolver(clientID), WithFormPostCallback())
 }

--- a/backend/pkg/server/oauth/oidc.go
+++ b/backend/pkg/server/oauth/oidc.go
@@ -1,0 +1,101 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+// OIDCProviderName is the provider name reported to the frontend for a generic
+// OpenID Connect identity provider such as Keycloak, Authentik, Okta or Entra ID.
+const OIDCProviderName = "oidc"
+
+// DefaultOIDCScopes are requested when no explicit scope list is configured.
+// The email scope is what makes the email claim available, and PentAGI matches
+// users by email.
+var DefaultOIDCScopes = []string{oidc.ScopeOpenID, "email", "profile"}
+
+type oidcTokenClaims struct {
+	Nonce         string `json:"nonce"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+}
+
+func newOIDCEmailResolver(provider *oidc.Provider, clientID string) OAuthEmailResolver {
+	verifier := provider.Verifier(&oidc.Config{ClientID: clientID})
+
+	return func(ctx context.Context, nonce string, token *oauth2.Token) (string, bool, error) {
+		rawIDToken, ok := token.Extra("id_token").(string)
+		if !ok {
+			return "", false, fmt.Errorf("id_token is not present in the token")
+		}
+
+		idToken, err := verifier.Verify(ctx, rawIDToken)
+		if err != nil {
+			return "", false, fmt.Errorf("could not verify OIDC ID Token: %w", err)
+		}
+
+		if idToken.Nonce != nonce {
+			return "", false, fmt.Errorf("nonce mismatch in OIDC ID Token")
+		}
+
+		claims := oidcTokenClaims{}
+		if err := idToken.Claims(&claims); err != nil {
+			return "", false, fmt.Errorf("failed to parse OIDC ID Token claims: %w", err)
+		}
+
+		if claims.Nonce != nonce {
+			return "", false, fmt.Errorf("nonce mismatch in OIDC ID Token claims")
+		}
+
+		if claims.Email != "" {
+			return claims.Email, claims.EmailVerified, nil
+		}
+
+		// Not every identity provider puts the email into the ID token, so fall
+		// back to the UserInfo endpoint before giving up.
+		userInfo, err := provider.UserInfo(ctx, oauth2.StaticTokenSource(token))
+		if err != nil {
+			return "", false, fmt.Errorf("email is empty in OIDC ID Token claims and UserInfo failed: %w", err)
+		}
+
+		if err := userInfo.Claims(&claims); err != nil {
+			return "", false, fmt.Errorf("failed to parse OIDC UserInfo claims: %w", err)
+		}
+
+		if claims.Email == "" {
+			return "", false, fmt.Errorf("email is empty in OIDC ID Token and UserInfo claims")
+		}
+
+		return claims.Email, claims.EmailVerified, nil
+	}
+}
+
+// NewOIDCOAuthClient builds an OAuth client for any OpenID Connect provider by
+// reading its discovery document. The issuer is the URL that serves
+// /.well-known/openid-configuration, for example
+// https://keycloak.example.com/realms/pentagi.
+func NewOIDCOAuthClient(
+	ctx context.Context,
+	issuer, clientID, clientSecret, redirectURL string,
+	scopes []string,
+) (OAuthClient, error) {
+	provider, err := oidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("could not create OpenID client for issuer '%s': %w", issuer, err)
+	}
+
+	if len(scopes) == 0 {
+		scopes = DefaultOIDCScopes
+	}
+
+	return NewOAuthClient(OIDCProviderName, &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		Scopes:       scopes,
+		Endpoint:     provider.Endpoint(),
+	}, newOIDCEmailResolver(provider, clientID)), nil
+}

--- a/backend/pkg/server/oauth/oidc_test.go
+++ b/backend/pkg/server/oauth/oidc_test.go
@@ -1,0 +1,131 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newDiscoveryServer serves a minimal OpenID Connect discovery document, which
+// is all NewOIDCOAuthClient needs to configure itself.
+func newDiscoveryServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                server.URL,
+			"authorization_endpoint":                server.URL + "/protocol/openid-connect/auth",
+			"token_endpoint":                        server.URL + "/protocol/openid-connect/token",
+			"userinfo_endpoint":                     server.URL + "/protocol/openid-connect/userinfo",
+			"jwks_uri":                              server.URL + "/protocol/openid-connect/certs",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestNewOIDCOAuthClientUsesDiscoveredEndpoints(t *testing.T) {
+	server := newDiscoveryServer(t)
+
+	client, err := NewOIDCOAuthClient(
+		context.Background(),
+		server.URL,
+		"pentagi",
+		"client-secret",
+		"https://pentagi.example.com/api/v1/auth/login-callback",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewOIDCOAuthClient() failed: %v", err)
+	}
+
+	if got := client.ProviderName(); got != OIDCProviderName {
+		t.Errorf("ProviderName() = %q, want %q", got, OIDCProviderName)
+	}
+
+	// A generic provider answers on a GET callback, so Lax cookies survive it.
+	if got := client.CallbackSameSite(); got != http.SameSiteLaxMode {
+		t.Errorf("CallbackSameSite() = %v, want %v", got, http.SameSiteLaxMode)
+	}
+
+	authURL := client.AuthCodeURL("state", client.AuthCodeOptions("nonce-value")...)
+	parsed, err := parseQuery(authURL)
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+
+	if want := server.URL + "/protocol/openid-connect/auth"; !strings.HasPrefix(authURL, want) {
+		t.Errorf("authorization URL = %q, want prefix %q", authURL, want)
+	}
+	if got := parsed.Get("nonce"); got != "nonce-value" {
+		t.Errorf("nonce = %q, want %q", got, "nonce-value")
+	}
+	if got := parsed.Get("response_type"); got != "code" {
+		t.Errorf("response_type = %q, want %q", got, "code")
+	}
+	if got := parsed.Get("scope"); got != "openid email profile" {
+		t.Errorf("scope = %q, want %q", got, "openid email profile")
+	}
+}
+
+func TestNewOIDCOAuthClientHonoursCustomScopes(t *testing.T) {
+	server := newDiscoveryServer(t)
+
+	client, err := NewOIDCOAuthClient(
+		context.Background(),
+		server.URL,
+		"pentagi",
+		"client-secret",
+		"https://pentagi.example.com/api/v1/auth/login-callback",
+		[]string{"openid", "email"},
+	)
+	if err != nil {
+		t.Fatalf("NewOIDCOAuthClient() failed: %v", err)
+	}
+
+	parsed, err := parseQuery(client.AuthCodeURL("state"))
+	if err != nil {
+		t.Fatalf("failed to parse authorization URL: %v", err)
+	}
+
+	if got := parsed.Get("scope"); got != "openid email" {
+		t.Errorf("scope = %q, want %q", got, "openid email")
+	}
+}
+
+func TestNewOIDCOAuthClientFailsOnUnreachableIssuer(t *testing.T) {
+	server := newDiscoveryServer(t)
+	issuer := server.URL
+	server.Close()
+
+	_, err := NewOIDCOAuthClient(
+		context.Background(),
+		issuer,
+		"pentagi",
+		"client-secret",
+		"https://pentagi.example.com/api/v1/auth/login-callback",
+		nil,
+	)
+	if err == nil {
+		t.Fatal("NewOIDCOAuthClient() succeeded for an unreachable issuer, want error")
+	}
+}
+
+func parseQuery(rawURL string) (url.Values, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return parsed.Query(), nil
+}

--- a/backend/pkg/server/router.go
+++ b/backend/pkg/server/router.go
@@ -46,6 +46,11 @@ const baseURL = "/api/v1"
 
 const corsAllowGoogleOAuth = "https://accounts.google.com"
 
+// oauthOIDCDiscoveryTimeout bounds the OpenID Connect discovery request made
+// while the server starts, so that an unreachable identity provider delays
+// startup by seconds instead of blocking it.
+const oauthOIDCDiscoveryTimeout = 10 * time.Second
+
 // frontendRoutes defines the list of URI prefixes that should be handled by the frontend SPA.
 // Add new frontend base routes here if they are added in the frontend router (e.g., in App.tsx).
 var frontendRoutes = []string{
@@ -123,6 +128,28 @@ func NewRouter(
 			publicURL.String(),
 		)
 		oauthClients[githubClient.ProviderName()] = githubClient
+	}
+
+	if publicURL != nil && cfg.OAuthOIDCIssuer != "" &&
+		cfg.OAuthOIDCClientID != "" && cfg.OAuthOIDCClientSecret != "" {
+		// Discovery talks to the identity provider, so give it a deadline and
+		// keep serving without the provider when the IdP is unreachable.
+		discoveryCtx, cancel := context.WithTimeout(context.Background(), oauthOIDCDiscoveryTimeout)
+		oidcClient, err := oauth.NewOIDCOAuthClient(
+			discoveryCtx,
+			cfg.OAuthOIDCIssuer,
+			cfg.OAuthOIDCClientID,
+			cfg.OAuthOIDCClientSecret,
+			publicURL.String(),
+			cfg.OAuthOIDCScopes,
+		)
+		cancel()
+		if err != nil {
+			logrus.WithError(err).
+				Errorf("failed to initialize OIDC provider '%s', SSO login is disabled", cfg.OAuthOIDCIssuer)
+		} else {
+			oauthClients[oidcClient.ProviderName()] = oidcClient
+		}
 	}
 
 	// ---- Knowledge (pgvector) store -----------------------------------------

--- a/backend/pkg/server/services/auth.go
+++ b/backend/pkg/server/services/auth.go
@@ -29,7 +29,6 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -243,7 +242,7 @@ func (s *AuthService) refreshCookie(c *gin.Context, resp *info, privs []string) 
 // @Tags Public
 // @Produce json
 // @Param return_uri query string false "URI to redirect user there after login" default(/)
-// @Param provider query string false "OAuth provider name (google, github, etc.)" default(google) enums:"google,github"
+// @Param provider query string false "OAuth provider name (google, github, oidc)" default(google) enums:"google,github,oidc"
 // @Success 307 "redirect to SSO login page"
 // @Failure 400 {object} response.errorResp "invalid autorizarion query"
 // @Failure 403 {object} response.errorResp "authorize not permitted"
@@ -304,24 +303,16 @@ func (s *AuthService) AuthAuthorize(c *gin.Context) {
 	signedStateJSON := append(signature, stateJSON...)
 	state := base64.RawURLEncoding.EncodeToString(signedStateJSON)
 
-	// Google OAuth uses POST callback which requires SameSite=None for cross-site requests
-	// GitHub and other providers use GET callback which works with SameSite=Lax
-	sameSiteMode := http.SameSiteLaxMode
-	if provider == "google" {
-		sameSiteMode = http.SameSiteNoneMode
-	}
+	// Providers answering with a cross-site form POST (Google) need SameSite=None
+	// for the temporary cookies; providers using a GET callback work with Lax.
+	sameSiteMode := oauthClient.CallbackSameSite()
 
 	maxAge := int(authStateRequestTTL / time.Second)
 	s.setCallbackCookie(c.Writer, c.Request, s.stateCookieName(), state, maxAge, sameSiteMode)
 	s.setCallbackCookie(c.Writer, c.Request, s.nonceCookieName(), nonce, maxAge, sameSiteMode)
 
-	authOpts := []oauth2.AuthCodeOption{
-		oauth2.SetAuthURLParam("nonce", nonce),
-		oauth2.SetAuthURLParam("response_mode", "form_post"),
-		oauth2.SetAuthURLParam("response_type", "code id_token"),
-	}
 	http.Redirect(c.Writer, c.Request,
-		oauthClient.AuthCodeURL(state, authOpts...),
+		oauthClient.AuthCodeURL(state, oauthClient.AuthCodeOptions(nonce)...),
 		http.StatusTemporaryRedirect)
 }
 
@@ -627,12 +618,11 @@ func (s *AuthService) authLoginCallback(c *gin.Context, stateData map[string]str
 		return
 	}
 
-	// delete temporary cookies
-	// Google OAuth uses POST callback which requires SameSite=None for cross-site requests
-	// GitHub and other providers use GET callback which works with SameSite=Lax
+	// delete temporary cookies with the same SameSite mode they were issued with,
+	// otherwise the browser keeps them until they expire
 	sameSiteMode := http.SameSiteLaxMode
-	if stateData["provider"] == "google" {
-		sameSiteMode = http.SameSiteNoneMode
+	if oauthClient, ok := s.oauth[stateData["provider"]]; ok {
+		sameSiteMode = oauthClient.CallbackSameSite()
 	}
 	s.setCallbackCookie(c.Writer, c.Request, s.stateCookieName(), "", 0, sameSiteMode)
 	s.setCallbackCookie(c.Writer, c.Request, s.nonceCookieName(), "", 0, sameSiteMode)

--- a/backend/pkg/server/services/auth_test.go
+++ b/backend/pkg/server/services/auth_test.go
@@ -44,6 +44,12 @@ func (f *fakeOAuthClient) RefreshToken(context.Context, string) (*oauth2.Token, 
 
 func (f *fakeOAuthClient) AuthCodeURL(string, ...oauth2.AuthCodeOption) string { return "" }
 
+func (f *fakeOAuthClient) AuthCodeOptions(nonce string) []oauth2.AuthCodeOption {
+	return []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("nonce", nonce)}
+}
+
+func (f *fakeOAuthClient) CallbackSameSite() http.SameSite { return http.SameSiteLaxMode }
+
 func newOAuthService(db *gorm.DB, email string) *AuthService {
 	return newOAuthServiceVerified(db, email, true)
 }

--- a/frontend/src/components/icons/sso.tsx
+++ b/frontend/src/components/icons/sso.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+
+interface SsoProps extends React.SVGProps<SVGSVGElement> {
+    className?: string;
+}
+
+function Sso({ className, ...props }: SsoProps) {
+    return (
+        <svg
+            className={cn(className)}
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
+            <path d="M12 2 4 5.5v6c0 5 3.4 9.2 8 10.5 4.6-1.3 8-5.5 8-10.5v-6z" />
+            <path d="M15 11a3 3 0 1 0-4.6 2.5V17h2.1v-2h1.6v-1.5h-1.6v-.6A3 3 0 0 0 15 11" />
+        </svg>
+    );
+}
+
+export default Sso;

--- a/frontend/src/features/authentication/login-form.test.tsx
+++ b/frontend/src/features/authentication/login-form.test.tsx
@@ -20,10 +20,10 @@ vi.mock('@/providers/user-provider', () => ({ useUser: () => userApi }));
 
 import LoginForm from './login-form';
 
-const renderLogin = () =>
+const renderLogin = (providers: string[] = []) =>
     render(
         <LoginForm
-            providers={[]}
+            providers={providers}
             returnUrl="/after-login"
         />,
     );
@@ -101,5 +101,24 @@ describe('LoginForm validation convention', () => {
 
         expect(await screen.findByText('Account locked')).toBeInTheDocument();
         expect(navigate).not.toHaveBeenCalled();
+    });
+});
+
+describe('LoginForm OAuth providers', () => {
+    it('offers only the providers the server advertises', () => {
+        renderLogin(['oidc']);
+
+        expect(screen.getByRole('button', { name: 'Continue with SSO' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Continue with Google' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Continue with GitHub' })).not.toBeInTheDocument();
+    });
+
+    it('starts the OAuth flow for the clicked provider', async () => {
+        const user = userEvent.setup();
+        renderLogin(['oidc']);
+
+        await user.click(screen.getByRole('button', { name: 'Continue with SSO' }));
+
+        await waitFor(() => expect(userApi.loginWithOAuth).toHaveBeenCalledWith('oidc'));
     });
 });

--- a/frontend/src/features/authentication/login-form.tsx
+++ b/frontend/src/features/authentication/login-form.tsx
@@ -6,6 +6,7 @@ import type { OAuthProvider } from '@/providers/user-provider';
 
 import Github from '@/components/icons/github';
 import Google from '@/components/icons/google';
+import Sso from '@/components/icons/sso';
 import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { FormSubmitButton } from '@/components/ui/form-submit-button';
@@ -53,6 +54,11 @@ const providerActions: AuthProviderAction[] = [
         icon: <Github className="size-5" />,
         id: 'github',
         name: 'Continue with GitHub',
+    },
+    {
+        icon: <Sso className="size-5" />,
+        id: 'oidc',
+        name: 'Continue with SSO',
     },
 ];
 

--- a/frontend/src/pages/settings/settings-account.tsx
+++ b/frontend/src/pages/settings/settings-account.tsx
@@ -17,6 +17,7 @@ type EditingSection = 'email' | 'name' | 'password';
 const PROVIDER_LABELS: Record<string, string> = {
     github: 'GitHub',
     google: 'Google',
+    oidc: 'SSO',
 };
 
 function SettingsAccount() {

--- a/frontend/src/providers/user-provider.tsx
+++ b/frontend/src/providers/user-provider.tsx
@@ -23,7 +23,7 @@ export interface LoginResult {
     success: boolean;
 }
 
-export type OAuthProvider = 'github' | 'google';
+export type OAuthProvider = 'github' | 'google' | 'oidc';
 
 interface UserContextType {
     authInfo: AuthInfo | null;


### PR DESCRIPTION
## Problem

PentAGI can delegate login to Google or GitHub. A self-hosted installation sitting behind a corporate identity provider — Keycloak, Authentik, Okta, Entra ID, Auth0 — has no way to use it, even though all of them speak plain OpenID Connect and `OAuthClient` is already an abstraction over a provider.

Writing the provider surfaced a smaller problem worth fixing along the way. The authorization request was built for Google and applied to everyone:

```go
authOpts := []oauth2.AuthCodeOption{
    oauth2.SetAuthURLParam("nonce", nonce),
    oauth2.SetAuthURLParam("response_mode", "form_post"),
    oauth2.SetAuthURLParam("response_type", "code id_token"),
}
```

and the SameSite mode of the temporary state/nonce cookies was decided by comparing the provider name to the string `"google"` in two separate places. GitHub tolerates the extra parameters, but a standards-compliant OIDC provider reads `response_type=code id_token` as a hybrid flow request and refuses it unless the client may use the implicit flow. Keycloak, with a normal confidential client, answers exactly this:

```
Client is not allowed to initiate browser login with given response_type.
Implicit flow is disabled for the client.
```

## What changed

Both decisions now belong to the provider:

- `AuthCodeOptions(nonce)` returns the parameters a provider expects. The default is a plain authorization code flow with a nonce. The new `WithFormPostCallback()` option adds the `form_post` pair and is applied to the Google client, so its behaviour is unchanged.
- `CallbackSameSite()` reports the SameSite mode the callback needs — `None` for a cross-site form POST, `Lax` otherwise. This replaces both `provider == "google"` comparisons, and the callback handler now clears the cookies with the same mode they were issued with instead of deciding again.

The new provider (`oidc`) configures itself from the issuer's discovery document, verifies the ID token signature and nonce, and resolves the email from the ID token, falling back to the UserInfo endpoint for providers that do not put an email there. Discovery runs once at startup with a ten second deadline: an unreachable identity provider is logged and skipped rather than blocking the server from starting.

## Configuration

```bash
PUBLIC_URL=https://pentagi.example.com
OAUTH_OIDC_ISSUER=https://keycloak.example.com/realms/pentagi
OAUTH_OIDC_CLIENT_ID=pentagi
OAUTH_OIDC_CLIENT_SECRET=your_client_secret
# optional, defaults to openid,email,profile
OAUTH_OIDC_SCOPES=openid,email,profile
```

The client is registered in the identity provider with the standard authorization code flow and the redirect URI `${PUBLIC_URL}/api/v1/auth/login-callback` — the same callback the existing providers use. The provider reaches the frontend through the existing `/info` providers list and renders on the login screen as **Continue with SSO**.

Accounts are matched by the `email` claim and created on first login with the regular `User` role, exactly as with Google and GitHub, so administrators are still promoted explicitly. PentAGI does not filter who may log in, which is noted in the docs together with the advice to bind the client to a group or policy on the identity provider side.

## Verification

Verified end to end on a local stand — PentAGI built from this branch, a real Keycloak and a real Authentik, browser driven through the full flow.

**Keycloak 26.0**, confidential client, implicit flow explicitly disabled:

- `/api/v1/info` advertises `providers: ["oidc"]`
- the authorization request is `response_type=code`, `code_challenge_method=S256`, `scope=openid email profile`, with a nonce
- login as `sso-user` lands an authenticated session and redirects to the return URI
- the account page shows the `SSO` badge and the email taken from the ID token

**Authentik 2025.8**, confidential OAuth2 provider created through its API:

- discovery against `http://…/application/o/pentagi/` succeeds at startup
- the same authorization code flow with PKCE completes
- login as `ak-user` creates the account and lands an authenticated session

Resulting users, both provisioned by the provider under test:

```
 id |         mail         | type  | provider | role
----+----------------------+-------+----------+------
  1 | admin@pentagi.com    | local |          | Admin
  2 | sso-user@stand.local | oauth | oidc     | User
  3 | ak-user@stand.local  | oauth | oidc     | User
```

The "before" behaviour is reproducible against the same Keycloak client: a request carrying `response_type=code id_token&response_mode=form_post` is refused with the implicit-flow error quoted above, while `response_type=code` renders the login page.

## Compatibility

- No behaviour change for existing installations: Google keeps `form_post` + `SameSite=None`, GitHub keeps its GET callback. GitHub no longer receives the two parameters it used to ignore.
- No new dependency — `github.com/coreos/go-oidc/v3` is already used by the Google provider.
- The provider stays absent unless issuer, client ID and client secret are all set.

## Checks

```
go build ./...                                     ok
go vet ./pkg/server/... ./pkg/config/...           ok
go test ./pkg/server/oauth/... ./pkg/server/services/...
ok  pentagi/pkg/server/oauth
ok  pentagi/pkg/server/services

pnpm exec tsc -b                                   No errors found
pnpm exec vitest run (touched suites)              PASS (17) FAIL (0)
pnpm exec eslint --max-warnings 0 (touched files)  No issues found
```

New tests cover the authorization parameters and cookie mode of both provider flavours, OIDC discovery with default and custom scopes, the unreachable-issuer path, and the login screen rendering only the providers the server advertises.